### PR TITLE
normalized the use of the Query object throughout the query stack

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/channel/BlockingBufferedConsumer.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/channel/BlockingBufferedConsumer.java
@@ -30,7 +30,7 @@ public class BlockingBufferedConsumer extends BlockingNullConsumer {
         table = Query.createProcessor(this).createTable(0);
     }
 
-    public BlockingBufferedConsumer(String ops) throws InterruptedException {
+    public BlockingBufferedConsumer(String ops[]) throws InterruptedException {
         table = Query.createProcessor(this, ops).createTable(0);
     }
 

--- a/hydra-data/src/main/java/com/addthis/hydra/data/query/QueryOpProcessor.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/query/QueryOpProcessor.java
@@ -218,9 +218,23 @@ public class QueryOpProcessor implements DataChannelOutput, DataTableFactory, Qu
     }
 
     public QueryOpProcessor parseOps(String ops) {
-        if (ops == null) {
+        if (ops == null || ops.length() == 0) {
             return this;
         }
+        return parseOps(new String[] { ops });
+    }
+
+    public QueryOpProcessor parseOps(String opslist[]) {
+        if (opslist == null || opslist.length == 0) {
+            return this;
+        }
+
+        /* remaining ops stack is processed in reverse order */
+        for (int i=opslist.length-1; i>=0; i--) {
+            String ops = opslist[i];
+            if (ops == null) {
+                continue;
+            }
 
         for (String s : Strings.split(ops, ";")) {
             KVPair kv = KVPair.parsePair(s);
@@ -361,6 +375,8 @@ public class QueryOpProcessor implements DataChannelOutput, DataTableFactory, Qu
                     appendOp(new OpTranspose(this));
                     break;
             }
+        }
+
         }
 
         return this;

--- a/hydra-data/src/main/java/com/addthis/hydra/data/query/channel/QueryChannelClient.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/query/channel/QueryChannelClient.java
@@ -28,6 +28,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import com.addthis.basis.util.JitterClock;
 
+import com.addthis.basis.util.Strings;
 import com.addthis.bundle.channel.DataChannelError;
 import com.addthis.bundle.channel.DataChannelOutput;
 import com.addthis.bundle.core.Bundle;
@@ -315,7 +316,7 @@ public class QueryChannelClient implements QuerySource {
         }
         for (ResultDelivery delivery : resultDeliveryCollection) {
             try {
-                delivery.handle(new QueryChannelResponse().setError("Query " + delivery.query.getPathString() + "\n\tFailed on " + host + " due to " + (e == null ? "" : e.getMessage())));
+                delivery.handle(new QueryChannelResponse().setError("Query " + Strings.join(delivery.query.getPaths(), "|") + "\n\tFailed on " + host + " due to " + (e == null ? "" : e.getMessage())));
             } catch (Exception e1)  {
                 log.warn("", e1);
             }

--- a/hydra-data/src/main/java/com/addthis/hydra/data/query/channel/QueryChannelServer.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/query/channel/QueryChannelServer.java
@@ -186,15 +186,15 @@ public class QueryChannelServer extends Thread {
             } catch (EOFException e) {
                 if (log.isWarnEnabled()) {
                     log.warn("[handler] EOF " + e, e);
-                    }
+                }
             } catch (SocketException e) {
                 if (log.isWarnEnabled()) {
                     // normal during query cancel
                     log.warn("[handler] Socket Exception " + e, e);
-                    }
+                }
             } catch (Exception e) {
                 log.warn("[handler] error " + e, e);
-                } finally {
+            } finally {
                 channel.flush();
             }
             return false;

--- a/hydra-data/src/test/java/com/addthis/hydra/data/query/TestQuery.java
+++ b/hydra-data/src/test/java/com/addthis/hydra/data/query/TestQuery.java
@@ -21,7 +21,7 @@ public class TestQuery {
     @Test
     public void testCompact() {
         String path = "+:+hits,+nodes$+foo=123/+/++123/+%top=hit/a,b,c/|foo/|+bar/*/+%goo/(1-5)+";
-        Query q = new Query("job", path, null);
-        Assert.assertEquals(path, q.getPathString());
+        Query q = new Query("job", new String[] { path }, null);
+        Assert.assertEquals(path, q.getPathString(q.getQueryPaths().get(0)));
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/query/QueryEngineSource.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/query/QueryEngineSource.java
@@ -74,7 +74,7 @@ public abstract class QueryEngineSource implements QuerySource {
                 engineGate.acquire(1);
                 engineGateHistogram.update(engineGate.availablePermits());
                 engine = getEngineLease();
-                engine.search(query.getPath(), consumer);
+                engine.search(query, consumer);
                 consumer.sendComplete();
             } catch (QueryException e) {
                 log.warn("query exception " + query.uuid() + " " + e + " " + consumer);

--- a/hydra-main/src/main/java/com/addthis/hydra/query/QueryServer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/query/QueryServer.java
@@ -272,7 +272,7 @@ public class QueryServer extends AbstractHandler {
         } else if (target.equals("/query/decode")) {
             String qo = "{path:" + kv.getValue("query", kv.getValue("path", "")) + "}";
             Query q = CodecJSON.decodeString(new Query(), qo);
-            response.getWriter().write(q.getPathString());
+            response.getWriter().write(q.getPaths()[0]);
         } else if (target.equals("/v2/queries/finished.list")) {
             JSONArray runningEntries = new JSONArray();
             for (QueryTracker.QueryEntryInfo entryInfo : tracker.getCompleted()) {

--- a/hydra-main/src/main/java/com/addthis/hydra/query/QueryTracker.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/query/QueryTracker.java
@@ -542,7 +542,7 @@ public class QueryTracker {
     public static class QueryEntryInfo implements Codec.Codable {
 
         @Codec.Set(codable = true)
-        public String path;
+        public String paths[];
         @Codec.Set(codable = true)
         public String uuid;
         @Codec.Set(codable = true)
@@ -558,7 +558,7 @@ public class QueryTracker {
         @Codec.Set(codable = true)
         public String job;
         @Codec.Set(codable = true)
-        public String ops;
+        public String ops[];
         @Codec.Set(codable = true)
         public long startTime;
         @Codec.Set(codable = true)
@@ -615,9 +615,7 @@ public class QueryTracker {
             this.cacheTTL = query.getParameter("cachettl") == null ? DEFAULT_CACHE_TTL : Long.valueOf(query.getParameter("cachettl"));
             this.noCache = query.getParameter("nocache") == null ? false : Boolean.valueOf(query.getParameter("nocache"));
             this.queryDetails = query.getJob() + "--" +
-                                query.getPathString() + "--" +
-                                (query.getOps() == null ? "" : query.getOps()) + "--" +
-                                (query.getRemoteOps() == null ? "" : query.getRemoteOps());
+                                (query.getOps() == null ? "" : query.getOps());
 
             this.cacheKey = queryDetails.hashCode();
             final String timeoutInSeconds = query.getParameter("timeout");
@@ -630,7 +628,7 @@ public class QueryTracker {
 
         public QueryEntryInfo toStat() {
             QueryEntryInfo stat = new QueryEntryInfo();
-            stat.path = query.getShortPathString();
+            stat.paths = query.getPaths();
             stat.uuid = query.uuid();
             stat.ops = query.getOps();
             stat.job = query.getJob();
@@ -717,7 +715,7 @@ public class QueryTracker {
                 if (error != null) {
                     log(new StringMapHelper()
                             .put("type", "query.error")
-                            .put("query.path", query.getShortPathString())
+                            .put("query.path", query.getPaths()[0])
                             .put("query.ops", query.getOps())
                             .put("sources", query.getParameter("sources"))
                             .put("time", System.currentTimeMillis())
@@ -737,7 +735,7 @@ public class QueryTracker {
 
                 StringMapHelper queryLine = new StringMapHelper()
                         .put("type", "query.done")
-                        .put("query.path", query.getShortPathString())
+                        .put("query.path", query.getPaths()[0])
                         .put("query.ops", query.getOps())
                         .put("sources", query.getParameter("sources"))
                         .put("time", System.currentTimeMillis())

--- a/hydra-main/src/test/java/com/addthis/hydra/query/TestMemEstimation.java
+++ b/hydra-main/src/test/java/com/addthis/hydra/query/TestMemEstimation.java
@@ -185,7 +185,7 @@ public class TestMemEstimation {
     }
 
     private void queryTreeScan() throws Exception {
-        query(new Query("nojob", "+/+", "merge=u"), tree);
+        query(new Query("nojob", new String[] { "+/+" }, new String[] { "merge=u" }), tree);
     }
 
     private void pause() throws InterruptedException, IOException {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
@@ -816,7 +816,7 @@ public final class TreeMapper extends DataOutputTypeList implements QuerySource,
                 Query.emitTrace("query begin " + query.uuid() + " " + query + " to " + consumer);
             }
             try {
-                queryEngine.search(query.getQueryPath(), consumer);
+                queryEngine.search(query, consumer);
                 consumer.sendComplete();
             } catch (QueryException e) {
                 consumer.sourceError(e);


### PR DESCRIPTION
direct use of QueryElement[] has been replaced by use of the Query object
queries are no longer converted to objects before reaching their destination
    path and ops arrays are simply encoded directly as the Query object and
    decoded at the destination (with the ops stack popped per below).  this
    also simplifies code and removes hard-coding of string params in client/server.
query paths can now be an array to permit future expansion such as easier date ranges
    either through a pre-processor built into the Query object or by direct client
    injection of multiple query paths. imagine ranging 2013/11/25 ro 2013/12/05. now
    it can be done as a single query with two paths embedded:
        /2013/11/25,26,27,28,29,30 and
        /2013/12/01,02,03,04,05
query ops are no longer ops and rops but rather an array (unbounded)
    this permits each node in the query chain to pull the top ops list
    and pass the rest to the next node.  in practice this yields the same
    results as ops/rops today but opens up the use of deeper query topologies.
    it also simplifies the code.
