### PR TITLE
Cleanup of error handling in AbstractOutputWriter.

### DIFF
--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractOutputWriter.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractOutputWriter.java
@@ -13,6 +13,8 @@
  */
 package com.addthis.hydra.task.output;
 
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 
 import java.util.ArrayList;
@@ -23,7 +25,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.addthis.basis.util.JitterClock;
 
@@ -35,8 +37,8 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import org.slf4j.Logger;
-
 import org.slf4j.LoggerFactory;
+
 /**
  * The OutputWriter has a single concurrent queue onto which bundles
  * are placed in preparation for moving these bundles to disk. One
@@ -105,22 +107,24 @@ public abstract class AbstractOutputWriter implements Codec.SuperCodable {
     private BundleFilter filter;
 
     private final Semaphore diskFlushThreadSemaphore = new Semaphore(0);
-
-    private final AtomicBoolean stopped = new AtomicBoolean(false);
+    private volatile boolean stopped = false;
+    private volatile boolean exiting = false;
+    private volatile boolean errored = false;
     private DiskFlushThread[] diskFlushThreadArray;
     protected ScheduledExecutorService writerMaintenanceThread =
             MoreExecutors.getExitingScheduledExecutorService(
                     new ScheduledThreadPoolExecutor(1,
                             new ThreadFactoryBuilder().setNameFormat("AbstractOutputWriterCleanUpThread-%d").build()));
     private QueueWriter queueWriter;
-    private final AtomicBoolean exiting = new AtomicBoolean(false);
+    private final AtomicReference<IOException> errorCause = new AtomicReference<>();
 
-    public final void writeLine(String file, Bundle nextLine) {
-        if (stopped.get()) {
+    public final void writeLine(String file, Bundle nextLine) throws IOException {
+        if (errored) {
+            throw new IOException(errorCause.get());
+        } else if (stopped) {
             log.warn("Tried to write a line after the writer has been stopped, line was: " + nextLine);
             throw new RuntimeException("Tried to write a line after the writer has been stopped");
-        }
-        if (filter == null || filter.filter(nextLine)) {
+        } else if (filter == null || filter.filter(nextLine)) {
             queueWriter.addBundle(file, nextLine);
         }
     }
@@ -129,19 +133,30 @@ public abstract class AbstractOutputWriter implements Codec.SuperCodable {
 
     public final void closeOpenOutputs() {
         try {
-            exiting.set(true);
+            exiting = true;
             // first stop the async flush threads
             shutdownMaintenanceThreads();
             shutdownDiskFlushThreads();
             queueWriter.drain(true);
             doCloseOpenOutputs();
         } finally {
-            stopped.set(true);
+            stopped = true;
         }
     }
 
     private boolean bufferSizeInRange(int bufferSize) {
         return bufferSize > maxBundles && bufferSize < maxBufferSize;
+    }
+
+    /**
+     * Sets the volatile boolean error variable and stores
+     * the first exception that is encountered.
+     *
+     * @param cause the error to store if it is the first exception
+     */
+    private void setErrorCause(@Nonnull IOException cause) {
+        errorCause.compareAndSet(null, cause);
+        errored = true;
     }
 
     @Override
@@ -233,6 +248,7 @@ public abstract class AbstractOutputWriter implements Codec.SuperCodable {
                 } catch (InterruptedException e) {
                     log.error("error writing to buffer: ", e);
                     tupleProcessed = true;
+                    setErrorCause(new IOException(e));
                 }
                 if (!tupleProcessed) {
                     try {
@@ -241,6 +257,7 @@ public abstract class AbstractOutputWriter implements Codec.SuperCodable {
                     } catch (IOException e) {
                         log.error("error dequeuing write: ", e);
                         tupleProcessed = true;
+                        setErrorCause(e);
                     }
                 }
             }
@@ -270,6 +287,7 @@ public abstract class AbstractOutputWriter implements Codec.SuperCodable {
                     dequeueWrite(outputList);
                 } catch (IOException e) {
                     log.error("error draining queue: ", e);
+                    setErrorCause(e);
                 }
             }
             while (iterate && size() > 0);
@@ -304,7 +322,7 @@ public abstract class AbstractOutputWriter implements Codec.SuperCodable {
 
                     int outstandingBundles;
                     do {
-                        if (exiting.get()) {
+                        if (exiting) {
                             return;
                         }
 
@@ -321,6 +339,7 @@ public abstract class AbstractOutputWriter implements Codec.SuperCodable {
                     while (outstandingBundles > maxBundles);
                 } catch (Exception ex) {
                     log.error("output writer disk flush error : ", ex);
+                    setErrorCause(new IOException(ex));
                 }
             }
         }
@@ -337,10 +356,10 @@ public abstract class AbstractOutputWriter implements Codec.SuperCodable {
         writerMaintenanceThread.shutdown();
         try {
             if (!writerMaintenanceThread.awaitTermination(30, TimeUnit.SECONDS)) {
-                log.warn("Waited 30 seconds for write maintenance termination but it did not finish");
+                log.error("Waited 30 seconds for write maintenance termination but it did not finish");
             }
         } catch (InterruptedException ie) {
-            log.warn("Thread interrupted while waiting for write maintenance termination");
+            log.error("Thread interrupted while waiting for write maintenance termination");
         }
     }
 
@@ -352,7 +371,7 @@ public abstract class AbstractOutputWriter implements Codec.SuperCodable {
                 diskFlushThreadArray[i].join();
             } catch (InterruptedException ex) {
                 log.error("shutdown disk flush threads error : ", ex);
-                }
+            }
         }
     }
 


### PR DESCRIPTION
 If an error is detected in any of the threads then record the error so that subsequent calls of writeLine(String, Bundle) will propagate the error to exit the job. Converted the fields 'stopped' and 'exiting' from AtomicBooleans to volatiles because no test-and-set operations are performed on these variables.
