### PR TITLE
Providing default 'format' value in output writers

### DIFF
--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractOutputWriter.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractOutputWriter.java
@@ -66,10 +66,10 @@ public abstract class AbstractOutputWriter implements Codec.SuperCodable {
 
     /**
      * Options for data layout within the output files.
-     * This field is required.
+     * The default is type "channel".
      */
-    @Codec.Set(codable = true, required = true)
-    protected OutputStreamFormatter format;
+    @Codec.Set(codable = true)
+    protected OutputStreamFormatter format = new OutputStreamChannel();
 
     /**
      * Maximum number of bundles that can be stored


### PR DESCRIPTION
For comparison, in the "mesh2" input source we already specify the "channel" formatter as the default when none is explicitly provided. Is there any reason why we should not specify the "channel" formatter as the default in the output writers? The current implementation has no default value ie. the field is required in the job specification.
