### PR TITLE
Add ability to merge multiple count-min sketch data attachments.

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataCounting.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataCounting.java
@@ -79,9 +79,7 @@ public class DataCounting extends TreeNodeData<DataCounting.Config> implements C
      *   put(x): offer x / show x to the estimator to be counted. 1 if the estimate changed, else 0.</pre>
      *
      * <p>If no command is specified or an invalid command is specified then the estimator returns as
-     * a custom value type. This custom value yields the correct estimate when merged across
-     * multiple nodes. The recommended usage is to provide no command to the remote query operations
-     * and then provide a command to the query master operation.
+     * a custom value type.
      *
      * <p>"%" operations are not supported.
      *


### PR DESCRIPTION
Allows for correct merging of two or more count min sketch attachments that are stored on multiple nodes.
Renaming the field "filter" to the field "sketch" so that it is not conflated with bundle or value
filters. Updated Javadoc documentation to reflect the recommended query operations for the count
min sketch data attachment and the probabilistic counter data attachment.
