### PR TITLE
Creating branch v4.1.5.1

### DIFF
--- a/hydra-avro/pom.xml
+++ b/hydra-avro/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>com.addthis.hydra</groupId>
     <artifactId>hydra-parent</artifactId>
-    <version>4.1.5</version>
+    <version>4.1.5.1</version>
   </parent>
 
   <artifactId>hydra-avro</artifactId>
@@ -38,6 +38,10 @@
       <version>1.7.6</version>
       <exclusions>
         <!-- avro uses an older version of slf4j-api -->
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>

--- a/hydra-data/pom.xml
+++ b/hydra-data/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>com.addthis.hydra</groupId>
     <artifactId>hydra-parent</artifactId>
-    <version>4.1.5</version>
+    <version>4.1.5.1</version>
   </parent>
 
   <artifactId>hydra-data</artifactId>

--- a/hydra-essentials/pom.xml
+++ b/hydra-essentials/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>com.addthis.hydra</groupId>
     <artifactId>hydra-parent</artifactId>
-    <version>4.1.5</version>
+    <version>4.1.5.1</version>
   </parent>
 
   <artifactId>hydra-essentials</artifactId>

--- a/hydra-filters/pom.xml
+++ b/hydra-filters/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>com.addthis.hydra</groupId>
     <artifactId>hydra-parent</artifactId>
-    <version>4.1.5</version>
+    <version>4.1.5.1</version>
   </parent>
   <name>Hydra Filters Module</name>
   <description>filters for hydra that can also be used stand-alone</description>

--- a/hydra-main-api/pom.xml
+++ b/hydra-main-api/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>com.addthis.hydra</groupId>
     <artifactId>hydra-parent</artifactId>
-    <version>4.1.5</version>
+    <version>4.1.5.1</version>
   </parent>
 
   <artifactId>hydra-main-api</artifactId>

--- a/hydra-main/pom.xml
+++ b/hydra-main/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>com.addthis.hydra</groupId>
     <artifactId>hydra-parent</artifactId>
-    <version>4.1.5</version>
+    <version>4.1.5.1</version>
   </parent>
 
   <artifactId>hydra-main</artifactId>

--- a/hydra-mq/pom.xml
+++ b/hydra-mq/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>com.addthis.hydra</groupId>
     <artifactId>hydra-parent</artifactId>
-    <version>4.1.5</version>
+    <version>4.1.5.1</version>
   </parent>
 
   <artifactId>hydra-mq</artifactId>

--- a/hydra-store/pom.xml
+++ b/hydra-store/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>com.addthis.hydra</groupId>
     <artifactId>hydra-parent</artifactId>
-    <version>4.1.5</version>
+    <version>4.1.5.1</version>
   </parent>
 
   <artifactId>hydra-store</artifactId>

--- a/hydra-task/pom.xml
+++ b/hydra-task/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>com.addthis.hydra</groupId>
     <artifactId>hydra-parent</artifactId>
-    <version>4.1.5</version>
+    <version>4.1.5.1</version>
   </parent>
 
   <artifactId>hydra-task</artifactId>

--- a/hydra-uber/pom.xml
+++ b/hydra-uber/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>com.addthis.hydra</groupId>
     <artifactId>hydra-parent</artifactId>
-    <version>4.1.5</version>
+    <version>4.1.5.1</version>
   </parent>
 
   <artifactId>hydra-uber</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <groupId>com.addthis.hydra</groupId>
   <artifactId>hydra-parent</artifactId>
   <name>hydra</name>
-  <version>4.1.5</version>
+  <version>4.1.5.1</version>
   <packaging>pom</packaging>
   <licenses>
     <license>
@@ -72,7 +72,7 @@
     <!-- hydra compression dependency versions -->
     <hydra.dep.compress.compress-lzf.version>0.9.8</hydra.dep.compress.compress-lzf.version>
     <hydra.dep.compress.jzlib.version>1.1.3</hydra.dep.compress.jzlib.version>
-    <hydra.dep.compress.snappy-java.version>1.0.5</hydra.dep.compress.snappy-java.version>
+    <hydra.dep.compress.snappy-java.version>1.0.4.1</hydra.dep.compress.snappy-java.version>
     <hydra.dep.compress.lzma-java.version>1.2</hydra.dep.compress.lzma-java.version>
     <hydra.dep.compress.apache.commons-compress.version>1.6</hydra.dep.compress.apache.commons-compress.version>
 


### PR DESCRIPTION
Reverting snappy to version 1.0.4.1 so that hydra will operate on older machines. This is a temporary solution until we either test the very latest version of snappy (with an embedded libstdc++ embedded for Linux/x86_64) or we remove the old machines or both of those conditions occur.
