### PR TITLE
upgrade meshy dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <hydra.dep.basis.version>2.2.0</hydra.dep.basis.version>
     <hydra.dep.bundle.version>2.2.3</hydra.dep.bundle.version>
     <hydra.dep.codec.version>2.0.3</hydra.dep.codec.version>
-    <hydra.dep.meshy.version>2.1.1</hydra.dep.meshy.version>
+    <hydra.dep.meshy.version>2.1.2</hydra.dep.meshy.version>
     <hydra.dep.muxy.version>2.0.3</hydra.dep.muxy.version>
     <hydra.dep.maljson.version>0.1.1</hydra.dep.maljson.version>
     <hydra.dep.streamlib.version>2.6.0-rc0</hydra.dep.streamlib.version>


### PR DESCRIPTION
This fixes a rare cause of hanging queries. It was possible for some pathological queries to create individual bundles on workers larger than (stream buffer + stream refill threshold). That is generally 1.5 MB. These were large enough to throw off the stream push/pull logic.
