### PR TITLE
extend hoover time format to support parsing of 'seconds' and 'milliseconds' timestamps (datasift/gnip)

### DIFF
--- a/hydra-task/src/main/java/com/addthis/hydra/task/hoover/Hoover.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/hoover/Hoover.java
@@ -308,7 +308,6 @@ public class Hoover extends TaskRunnable implements Runnable {
         this.mods = config.calcShardList(config.nodeCount);
         this.markRoot = Files.initDirectory(new File(markDir));
         this.datePattern = Pattern.compile(dateMatcher);
-//        this.dateFormat = new SimpleDateFormat(dateExtractor);
         if (startDate != null) {
             this.jodaStartDate = DateUtil.getDateTime(DateUtil.getFormatter(startEndDateFormat), startDate);
         }


### PR DESCRIPTION
add more debug logging for hoover jobs controllable by job params. allow tracing stderr.
