### PR TITLE
support simple usages of typesafe-config job conf

### DIFF
--- a/hydra-main/pom.xml
+++ b/hydra-main/pom.xml
@@ -72,6 +72,11 @@
 
     <!-- 3rd part deps -->
     <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <version>3.0</version>

--- a/hydra-main/src/main/resources/plugins/core-executables.classmap
+++ b/hydra-main/src/main/resources/plugins/core-executables.classmap
@@ -4,6 +4,7 @@
 "mqworker", com.addthis.hydra.query.MeshQueryWorker
 "qutil", com.addthis.hydra.query.util.QueryChannelUtil
 "task", com.addthis.hydra.task.run.TaskRunner
+"hocon", com.addthis.hydra.task.run.HoconRunner
 "fmux", com.addthis.muxy.Main
 "cliquery", com.addthis.hydra.data.query.CLIQuery
 "printbundles", com.addthis.hydra.task.util.BundleStreamPeeker

--- a/hydra-task/pom.xml
+++ b/hydra-task/pom.xml
@@ -76,6 +76,11 @@
       <version>8.1.4.v20120524</version>
     </dependency>
     <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.0.1</version>

--- a/hydra-task/src/main/java/com/addthis/hydra/task/run/HoconRunner.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/run/HoconRunner.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.addthis.hydra.task.run;
+
+import java.io.File;
+
+import com.addthis.basis.util.Parameter;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigRenderOptions;
+
+/**
+ * Main method invoked when running tasks.
+ * <p/>
+ * "usage: hocon <config> <nodes> <node> [jobid] [threads]"
+ */
+public class HoconRunner {
+
+    static final boolean resolvePrint = Parameter.boolValue("task.hocon.resolvePrint", false);
+    static final boolean toJson = Parameter.boolValue("task.hocon.toJson", false);
+    static final boolean keepComments = Parameter.boolValue("task.hocon.keepComments", false);
+    static final boolean debugComments = Parameter.boolValue("task.hocon.debugComments", false);
+
+    /**
+     * @param args
+     * @throws Exception
+     */
+    public static void main(String args[]) throws Exception {
+        if (args.length < 1) {
+            System.out.println("usage: hocon <config> <nodes> <node> [jobid] [threads]");
+            return;
+        }
+        String fileName = args[0];
+        if (args.length < 2) {
+            loadHoconAndPrintVarious(fileName);
+            return;
+        }
+        int nodeCount = Integer.parseInt(args[1]);
+        int thisNode = Integer.parseInt(args[2]);
+        String jobId = (args.length > 3) ? args[3] : null;
+        int commandLineThreads = (args.length > 4) ? Integer.parseInt(args[4]) : TaskRunner.defaultThreads;
+
+        String configString = loadHoconAndPrintJson(fileName);
+
+        TaskRunner.runTask(configString, nodeCount, thisNode, jobId, commandLineThreads);
+    }
+
+    public static String loadHoconAndPrintJson(String fileName) {
+        Config config = ConfigFactory.parseFile(new File(fileName));
+        return config.resolve().root().render(ConfigRenderOptions.concise());
+    }
+
+    public static void loadHoconAndPrintVarious(String fileName) {
+        Config config = ConfigFactory.parseFile(new File(fileName));
+        if (resolvePrint) {
+            config = config.resolve();
+        }
+        ConfigRenderOptions renderOptions = ConfigRenderOptions.defaults()
+                .setComments(keepComments)
+                .setOriginComments(debugComments)
+                .setJson(toJson);
+        String configString = config.root().render(renderOptions);
+        System.out.println(configString);
+    }
+}


### PR DESCRIPTION
Supports basic usage of typesafe-config syntax for job configs. It is simple in the sense that config files
are parsed as stand alone files without any inheritance or merging or integration of fancier features like
replacing job param or macro syntax with built-in hocon substitution. Also, I did not alter the 'validate job'
function to preprocess first (although that would be simple to hack, it would be cleaner with a job-level
property for type ala. map/hoover/etc but not in the config itself). The way it works is also pretty straight
forward:
1. parse file with typesafe
2. render config resultant config object as a json string
3. give json string to normal task runner

For a small sample of the additional syntax it allows (hocon is pretty much a superset of malJson):

```
type=map

source.type=empty
source.maxPackets=100000

map {
    fields=[]
    filterOut.op=map
    filterOut.fields=[
            { from=counter, filter { op=count, format="0000000" } }
            { from=DATE_YMD, filter { op=time-range
                                        offsetDays=-1
                                        now=true
                                        format=YYMMdd }}
    ]
}

output.type=tree
output {
    root.path=TREE
    paths.TREE=[
            { type=const, value=empty }
    ]
}
```

versus the original version:

```
{
  type : "map",
       source : {
         type : "empty",
         maxPackets : 100000,
       },
       map : {
         fields : [],
         filterOut :
         {op:"map", fields:[
           {from:"counter", filter: {op:"count", format:"0000000"}},
           {from: "DATE_YMD", filter: {op: "time-range", offsetDays:-1, now:true, format:"YYMMdd"}},
           ]},
       },
       output : {
         type:"tree",
         root:{path:"TREE"},
         paths:{
           TREE:[
           {type:"const", value:"empty"},
           ]
         },
       }
}
```
