### PR TITLE
couple clean ups for spawn

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/job/SpawnQueuesByPriority.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/SpawnQueuesByPriority.java
@@ -93,6 +93,10 @@ public class SpawnQueuesByPriority extends TreeMap<Integer, LinkedList<SpawnQueu
         return queueLock.tryLock();
     }
 
+    public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+        return queueLock.tryLock(time, unit);
+    }
+
     public boolean addTaskToQueue(int priority, JobKey task, boolean canIgnoreQuiesce, boolean toHead) {
         queueLock.lock();
         try {


### PR DESCRIPTION
- uses tryLock(timeout) instead of if tryLock() else sleep(timeout)
- two cases of creating arrays to iterate over instead of just iterating
  over the collection. toArray is implemented as an iterator call by
  default anyway so I can't think of any reason for this
- collapsed a nested try statement
