### PR TITLE
Add support for CSV arrays in RPN calculator.

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/query/op/OpNumber.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/query/op/OpNumber.java
@@ -266,6 +266,15 @@ import com.addthis.hydra.data.query.AbstractRowOp;
  * <td>push the value X onto the stack</td>
  * <td>1</td>
  * </tr>
+ * <tr>
+ * <td>"vector"</td>
+ * <td>0</td>
+ * <td>modifies the behavior of the next operation.<br>
+ * Next operation pops all elements off the stack<br>
+ * and pushes a single value onto the stack. Available<br>
+ * for "+", "mult", "dmult", "min", and "max".
+ * <td>0</td>
+ * </tr>
  * </table>
  * <p/>
  * <p/>

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterNum.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterNum.java
@@ -271,6 +271,15 @@ import com.addthis.hydra.data.filter.util.BundleCalculator;
  * <td>push the value X onto the stack</td>
  * <td>1</td>
  * </tr>
+ * <tr>
+ * <td>"vector"</td>
+ * <td>0</td>
+ * <td>modifies the behavior of the next operation.<br>
+ * Next operation pops all elements off the stack<br>
+ * and pushes a single value onto the stack. Available<br>
+ * for "+", "mult", "dmult", "min", and "max".
+ * <td>0</td>
+ * </tr>
  * </table>
  * <p>Examples:</p>
  * <pre>

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/util/BundleCalculatorVector.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/util/BundleCalculatorVector.java
@@ -1,0 +1,100 @@
+package com.addthis.hydra.data.filter.util;
+
+import com.addthis.bundle.value.ValueArray;
+import com.addthis.bundle.value.ValueBytes;
+import com.addthis.bundle.value.ValueCustom;
+import com.addthis.bundle.value.ValueDouble;
+import com.addthis.bundle.value.ValueLong;
+import com.addthis.bundle.value.ValueMap;
+import com.addthis.bundle.value.ValueNumber;
+import com.addthis.bundle.value.ValueString;
+import com.addthis.bundle.value.ValueTranslationException;
+
+/**
+ * This singleton class is used to signal on the
+ * {@link com.addthis.hydra.data.filter.util.BundleCalculator}
+ * value stack that the immediately following operation
+ * should be a vector operation. This class throws
+ * IllegalStateException if any attempt is made to read a value from
+ * the object.
+ */
+class BundleCalculatorVector implements ValueNumber {
+
+    private static final BundleCalculatorVector singleton = new BundleCalculatorVector();
+
+    public static BundleCalculatorVector getSingleton() {
+        return singleton;
+    }
+
+    private BundleCalculatorVector() {}
+
+    @Override
+    public ValueNumber sum(ValueNumber val) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public ValueNumber diff(ValueNumber val) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public ValueNumber avg(int count) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public ValueNumber min(ValueNumber val) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public ValueNumber max(ValueNumber val) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public TYPE getObjectType() {
+        return TYPE.CUSTOM;
+    }
+
+    @Override
+    public ValueBytes asBytes() throws ValueTranslationException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public ValueArray asArray() throws ValueTranslationException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public ValueMap asMap() throws ValueTranslationException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public ValueNumber asNumber() throws ValueTranslationException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public ValueLong asLong() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public ValueDouble asDouble() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public ValueString asString() throws ValueTranslationException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public ValueCustom asCustom() throws ValueTranslationException {
+        throw new IllegalStateException();
+    }
+}

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterNum.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterNum.java
@@ -45,6 +45,35 @@ public class TestBundleFilterNum extends TestBundleFilter {
     }
 
     @Test
+    public void testVectorOps() {
+        BundleFilterNum bfn = new BundleFilterNum().setDefine("n1,n2,n3,n4,vector,*,v0,set");
+        Bundle bundle = new ListBundle();
+        bundle.setValue(bundle.getFormat().getField("c0"), ValueFactory.create(0));
+        bfn.filter(bundle);
+        assertEquals("24", bundle.getValue(bundle.getFormat().getField("c0")).toString());
+
+        bfn = new BundleFilterNum().setDefine("n1,n2,n3,n4,vector,+,v0,set");
+        bundle = new ListBundle();
+        bundle.setValue(bundle.getFormat().getField("c0"), ValueFactory.create(0));
+        bfn.filter(bundle);
+        assertEquals("10", bundle.getValue(bundle.getFormat().getField("c0")).toString());
+
+        bfn = new BundleFilterNum().setDefine("n1,n2,n3,n4,vector,min,v0,set");
+        bundle = new ListBundle();
+        bundle.setValue(bundle.getFormat().getField("c0"), ValueFactory.create(0));
+        bfn.filter(bundle);
+        assertEquals("1", bundle.getValue(bundle.getFormat().getField("c0")).toString());
+
+        bfn = new BundleFilterNum().setDefine("n1,n2,n3,n4,vector,max,v0,set");
+        bundle = new ListBundle();
+        bundle.setValue(bundle.getFormat().getField("c0"), ValueFactory.create(0));
+        bfn.filter(bundle);
+        assertEquals("4", bundle.getValue(bundle.getFormat().getField("c0")).toString());
+
+    }
+
+
+    @Test
     public void testInsertArray() {
         BundleFilterNum bfn = new BundleFilterNum().setDefine("c0,mean,v1,set");
         Bundle bundle = new ListBundle();


### PR DESCRIPTION
This feature may be useful in combination with the merge operation
that appends keys together with a "," separator.
