### PR TITLE
Least harmful method of fixing '@' query notation.

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/query/QueryElementNode.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/query/QueryElementNode.java
@@ -154,9 +154,13 @@ public class QueryElementNode implements Codec.Codable {
                 }
                 continue;
             }
-            if (component.startsWith("@")) {
-                path = Strings.splitArray(Bytes.urldecode(component.substring(1)), "/");
+            if (component.startsWith("@@")) {
+                path = Strings.splitArray(Bytes.urldecode(component.substring(2)), "/");
                 continue;
+            } else if (component.startsWith("@")) {
+                component = component.substring(1);
+                mode = MODE.MATCH;
+                rangeStrict = true;
             }
             component = Bytes.urldecode(component);
             if (component.length() > 0) {


### PR DESCRIPTION
The new '+@' query path prefix has a semantic behavior that is completely
different from the '@' query path prefix. This commit renames the '@' path
prefix to the '@@' prefix and adds the '@' path prefix
to perform the same function as the '+@' prefix only without collecting the results.
