### PR TITLE
MarkDB database errors should error the job.

### DIFF
--- a/hydra-avro/src/main/java/com/addthis/hydra/task/source/DataSourceAvro.java
+++ b/hydra-avro/src/main/java/com/addthis/hydra/task/source/DataSourceAvro.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.addthis.bundle.channel.DataChannelError;
 import com.addthis.bundle.core.Bundle;
@@ -66,7 +67,7 @@ public class DataSourceAvro extends TaskDataSource implements BundleFactory {
     private InputStream inputStream;
 
     @Override
-    protected void open(TaskRunConfig config) {
+    protected void open(TaskRunConfig config, AtomicBoolean errored) {
 
         setDatumReader(new GenericDatumReader<GenericRecord>(new Schema.Parser().parse(schema)));
         try {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamMapper.java
@@ -118,6 +118,7 @@ public class StreamMapper extends TaskRunnable implements StreamEmitter, TaskRun
 
     private final AtomicLong totalEmit = new AtomicLong(0);
     private final AtomicBoolean emitGate = new AtomicBoolean(false);
+    private final AtomicBoolean errored = new AtomicBoolean(false);
     private final long startTime = JitterClock.globalTime();
     private long lastMark;
     private TaskRunConfig config;
@@ -238,7 +239,7 @@ public class StreamMapper extends TaskRunnable implements StreamEmitter, TaskRun
         if (map == null) {
             map = new MapDef();
         }
-        getSource().init(config);
+        getSource().init(config, errored);
         getOutput().init(config);
         if (builder != null) {
             builder.init();
@@ -406,5 +407,9 @@ public class StreamMapper extends TaskRunnable implements StreamEmitter, TaskRun
         getOutput().sendComplete();
         log.info("[taskComplete]");
         emitTaskExitState();
+    }
+
+    public AtomicBoolean getErrored() {
+        return errored;
     }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/run/TaskFeeder.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/run/TaskFeeder.java
@@ -77,7 +77,7 @@ public final class TaskFeeder extends Thread {
     private final Thread threads[];
     private final BlockingQueue<Bundle> queues[];
     private volatile boolean queuesInit;
-    private final AtomicBoolean errored = new AtomicBoolean(false);
+    private final AtomicBoolean errored;
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final AtomicInteger processed = new AtomicInteger(0);
     private final AtomicLong totalReads = new AtomicLong(0);
@@ -96,6 +96,7 @@ public final class TaskFeeder extends Thread {
         modHistrogram = Metrics.newHistogram(getClass(), "mod");
 
         this.source = task.getSource();
+        this.errored = task.getErrored();
         this.task = task;
         this.readers = feeders;
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/run/TaskRunTarget.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/run/TaskRunTarget.java
@@ -13,6 +13,8 @@
  */
 package com.addthis.hydra.task.run;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import com.addthis.bundle.core.Bundle;
 import com.addthis.hydra.task.source.TaskDataSource;
 
@@ -20,6 +22,8 @@ import com.addthis.hydra.task.source.TaskDataSource;
 public interface TaskRunTarget {
 
     public TaskDataSource getSource();
+
+    public AtomicBoolean getErrored();
 
     /**
      * called during normal processing

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/AbstractDataSourceWrapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/AbstractDataSourceWrapper.java
@@ -13,6 +13,8 @@
  */
 package com.addthis.hydra.task.source;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import com.addthis.bundle.channel.DataChannelError;
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.Codec;
@@ -41,8 +43,8 @@ public abstract class AbstractDataSourceWrapper extends TaskDataSource {
     }
 
     @Override
-    public void open(TaskRunConfig config) throws DataChannelError {
-        source.open(config);
+    public void open(TaskRunConfig config, AtomicBoolean errored) throws DataChannelError {
+        source.open(config, errored);
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/AggregateTaskDataSource.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/AggregateTaskDataSource.java
@@ -14,6 +14,7 @@
 package com.addthis.hydra.task.source;
 
 import java.util.LinkedList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.addthis.bundle.channel.DataChannelError;
 import com.addthis.bundle.core.Bundle;
@@ -97,12 +98,12 @@ public class AggregateTaskDataSource extends TaskDataSource {
     }
 
     @Override
-    public void open(TaskRunConfig config) {
+    public void open(TaskRunConfig config, AtomicBoolean errored) {
         for (int i = 0; i < sources.length; i++) {
             TaskDataSource source = sources[i];
             if (source.isEnabled()) {
                 if (log.isDebugEnabled()) log.debug("open " + source);
-                source.open(config);
+                source.open(config, errored);
                 sourceList.add(source);
             } else {
                 if (log.isDebugEnabled()) log.debug("disabled " + source);

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceChannel.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceChannel.java
@@ -16,6 +16,8 @@ package com.addthis.hydra.task.source;
 import java.io.EOFException;
 import java.io.IOException;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import com.addthis.bundle.channel.DataChannelError;
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleFactory;
@@ -44,7 +46,7 @@ public class DataSourceChannel extends TaskDataSource implements BundleFactory {
     private Bundle peek;
 
     @Override
-    protected void open(TaskRunConfig config) {
+    protected void open(TaskRunConfig config, AtomicBoolean errored) {
         try {
             reader = new DataChannelReader(this, input.createInputStream(config));
         } catch (IOException e) {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceEmpty.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceEmpty.java
@@ -14,6 +14,7 @@
 package com.addthis.hydra.task.source;
 
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.addthis.bundle.core.Bundle;
@@ -48,7 +49,7 @@ public class DataSourceEmpty extends TaskDataSource {
     }
 
     @Override
-    public void open(TaskRunConfig config) {
+    public void open(TaskRunConfig config, AtomicBoolean errored) {
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceFiltered.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceFiltered.java
@@ -14,6 +14,7 @@
 package com.addthis.hydra.task.source;
 
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.Codec;
@@ -78,8 +79,8 @@ public class DataSourceFiltered extends TaskDataSource {
     private Bundle peek;
 
     @Override
-    public void open(TaskRunConfig config) {
-        stream.open(config);
+    public void open(TaskRunConfig config, AtomicBoolean errored) {
+        stream.open(config, errored);
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceHashed.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceHashed.java
@@ -14,6 +14,7 @@
 package com.addthis.hydra.task.source;
 
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.Codec;
@@ -51,9 +52,9 @@ public class DataSourceHashed extends TaskDataSource {
     private Integer[] shards;
 
     @Override
-    public void open(TaskRunConfig config) {
+    public void open(TaskRunConfig config, AtomicBoolean errored) {
         shards = config.calcShardList(shardTotal);
-        stream.open(config);
+        stream.open(config, errored);
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourcePrefetch.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourcePrefetch.java
@@ -14,6 +14,7 @@
 package com.addthis.hydra.task.source;
 
 import java.util.LinkedList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.Codec;
@@ -49,8 +50,8 @@ public final class DataSourcePrefetch extends TaskDataSource {
     }
 
     @Override
-    public void open(TaskRunConfig config) {
-        source.open(config);
+    public void open(TaskRunConfig config, AtomicBoolean errored) {
+        source.open(config, errored);
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceRange.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceRange.java
@@ -13,6 +13,8 @@
  */
 package com.addthis.hydra.task.source;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import com.addthis.bundle.channel.DataChannelError;
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.Codec;
@@ -69,8 +71,8 @@ public class DataSourceRange extends TaskDataSource {
     }
 
     @Override
-    protected void open(TaskRunConfig config) {
-        source.open(config);
+    protected void open(TaskRunConfig config, AtomicBoolean errored) {
+        source.open(config, errored);
     }
 
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/SortedTaskDataSource.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/SortedTaskDataSource.java
@@ -15,6 +15,7 @@ package com.addthis.hydra.task.source;
 
 import java.util.Iterator;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.addthis.bundle.channel.DataChannelError;
 import com.addthis.bundle.core.Bundle;
@@ -60,8 +61,8 @@ public class SortedTaskDataSource extends TaskDataSource {
     }
 
     @Override
-    protected void open(TaskRunConfig config) {
-        source.open(config);
+    protected void open(TaskRunConfig config, AtomicBoolean errored) {
+        source.open(config, errored);
     }
 
     private void fill() {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/SourceTracker.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/SourceTracker.java
@@ -20,6 +20,8 @@ import java.io.RandomAccessFile;
 
 import java.net.SocketTimeoutException;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import java.nio.channels.FileLock;
 
 import com.addthis.basis.util.Files;
@@ -70,8 +72,8 @@ public class SourceTracker {
         }
     }
 
-    public void open(final TaskDataSource source) {
-        source.open(sourceConfig);
+    public void open(final TaskDataSource source, AtomicBoolean errored) {
+        source.open(sourceConfig, errored);
     }
 
     /**
@@ -160,8 +162,8 @@ public class SourceTracker {
      * @param source source to index and track
      * @return wrapped source or null if it could not be tracked
      */
-    public TaskDataSource openAndInit(final TaskDataSource source) {
-        open(source);
+    public TaskDataSource openAndInit(final TaskDataSource source, AtomicBoolean errored) {
+        open(source, errored);
         return init(source);
     }
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/TaskDataSource.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/TaskDataSource.java
@@ -14,6 +14,8 @@
 package com.addthis.hydra.task.source;
 
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import com.addthis.bundle.channel.DataChannelSource;
 import com.addthis.bundle.core.BundleField;
 import com.addthis.codec.Codec;
@@ -97,10 +99,10 @@ public abstract class TaskDataSource implements Codec.Codable, DataChannelSource
         return false;
     }
 
-    protected abstract void open(TaskRunConfig config);
+    protected abstract void open(TaskRunConfig config, AtomicBoolean errored);
 
-    public final void init(TaskRunConfig config) {
-        open(config);
+    public final void init(TaskRunConfig config, AtomicBoolean errored) {
+        open(config, errored);
     }
 
     public final BundleField getShardField() {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/TaskDataSourceAggregator.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/TaskDataSourceAggregator.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map.Entry;
 import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.hydra.task.run.TaskRunConfig;
@@ -40,7 +41,8 @@ public class TaskDataSourceAggregator extends TaskDataSource {
     private TaskDataSource currentSource;
     private SourceTracker tracker;
 
-    public TaskDataSourceAggregator(Collection<TaskDataSource> sourceList, TaskDataSourceSelector sourceSelector, SourceTracker tracker) {
+    public TaskDataSourceAggregator(Collection<TaskDataSource> sourceList, TaskDataSourceSelector sourceSelector,
+            SourceTracker tracker, AtomicBoolean errored) {
         if (sourceList == null || sourceSelector == null) {
             throw new NullPointerException();
         }
@@ -52,7 +54,7 @@ public class TaskDataSourceAggregator extends TaskDataSource {
 
         for (TaskDataSource taskDataSource : sourceList) {
             if (this.tracker != null) {
-                TaskDataSource tracked = tracker.openAndInit(taskDataSource);
+                TaskDataSource tracked = tracker.openAndInit(taskDataSource, errored);
                 this.sources.put(taskDataSource, (tracked != null) ? tracked : taskDataSource);
             } else {
                 this.sources.put(taskDataSource, taskDataSource);
@@ -67,7 +69,7 @@ public class TaskDataSourceAggregator extends TaskDataSource {
     }
 
     @Override
-    protected void open(TaskRunConfig config) {
+    protected void open(TaskRunConfig config, AtomicBoolean errored) {
         // nothing to do
     }
 

--- a/hydra-task/src/test/java/com/addthis/hydra/task/source/AggregateTaskDataSourceTest.java
+++ b/hydra-task/src/test/java/com/addthis/hydra/task/source/AggregateTaskDataSourceTest.java
@@ -13,6 +13,8 @@
  */
 package com.addthis.hydra.task.source;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import com.addthis.hydra.task.run.TaskRunConfig;
 
 import org.easymock.EasyMock;
@@ -28,8 +30,8 @@ public class AggregateTaskDataSourceTest {
         TaskDataSource mockDS2 = EasyMock.createMock(TaskDataSource.class);
         aggregateTaskDataSource.setSources(new TaskDataSource[]{mockDS1, mockDS2});
 
-        mockDS1.open(EasyMock.isA(TaskRunConfig.class));
-        mockDS2.open(EasyMock.isA(TaskRunConfig.class));
+        mockDS1.open(EasyMock.isA(TaskRunConfig.class), EasyMock.isA(AtomicBoolean.class));
+        mockDS2.open(EasyMock.isA(TaskRunConfig.class), EasyMock.isA(AtomicBoolean.class));
 
         EasyMock.expect(mockDS1.isEnabled()).andReturn(true);
         EasyMock.expect(mockDS2.isEnabled()).andReturn(true);
@@ -38,7 +40,7 @@ public class AggregateTaskDataSourceTest {
         EasyMock.expect(mockDS2.peek()).andReturn(null);
 
         EasyMock.replay(mockDS1, mockDS2);
-        aggregateTaskDataSource.open(new TaskRunConfig(3, 9, "foo"));
+        aggregateTaskDataSource.open(new TaskRunConfig(3, 9, "foo"), new AtomicBoolean());
         EasyMock.verify(mockDS1, mockDS2);
     }
 
@@ -49,8 +51,8 @@ public class AggregateTaskDataSourceTest {
         TaskDataSource mockDS2 = EasyMock.createMock(TaskDataSource.class);
         aggregateTaskDataSource.setSources(new TaskDataSource[]{mockDS1, mockDS2});
 
-        mockDS1.open(EasyMock.isA(TaskRunConfig.class));
-        mockDS2.open(EasyMock.isA(TaskRunConfig.class));
+        mockDS1.open(EasyMock.isA(TaskRunConfig.class), EasyMock.isA(AtomicBoolean.class));
+        mockDS2.open(EasyMock.isA(TaskRunConfig.class), EasyMock.isA(AtomicBoolean.class));
 
         EasyMock.expect(mockDS1.isEnabled()).andReturn(true);
         EasyMock.expect(mockDS2.isEnabled()).andReturn(true);
@@ -59,7 +61,7 @@ public class AggregateTaskDataSourceTest {
         EasyMock.expect(mockDS2.peek()).andReturn(null);
 
         EasyMock.replay(mockDS1, mockDS2);
-        aggregateTaskDataSource.open(new TaskRunConfig(3, 9, "foo"));
+        aggregateTaskDataSource.open(new TaskRunConfig(3, 9, "foo"), new AtomicBoolean());
         aggregateTaskDataSource.peek();
         EasyMock.verify(mockDS1, mockDS2);
     }


### PR DESCRIPTION
Previously markDB database errors were silent. They were logged in
the standard output and job continued to execute normally. Now these
errors cause the job to exit abnormally. This commit touches a lot of
files but most files have minor changes. The logic for erroring a job
is buried in TaskFeeder. I had to pass around an AtomicBoolean so that
all threads involved would be reading and/or writing the same state
to determine if a job has errored. To engage the old behavior of silent
failure set 'hydra.markdb.error.ignore' to True.

I have tested this change on local stack by creating a split job with a novel encoding scheme, and then downgrading the hydra job so that the encoding scheme is unrecognized. Previously the job would run to completion. Now the job errors. A split job must be used because a map job would successfully error as PageDB errors in the 'map' section of the job will cause the job to error.
