### PR TITLE
Refactored job save API and some spawn fixes

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/job/Job.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/Job.java
@@ -62,117 +62,117 @@ public final class Job implements IJob, Codable {
     };
 
     /* what is the state of this job */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private int state;
     /* how many tasks are active */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private int countActiveTasks;
     /* who created this job */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private String creator;
     /* who last modified this job */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private String owner;
     /* purely ornamental description of this job */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private String description;
     /* key used for storing / retrieving this job */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private String id;
     /* higher means more important */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private int priority;
     /* will stomp lower pri jobs to create capacity */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private boolean stomp;
     /* Unix epoch offset of time job was created */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private Long createTime;
     /* Unix epoch offset of time job was last submitted */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private Long submitTime;
     /* Unix epoch offset of time first job node was assigned */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private Long startTime;
     /* Unix epoch offset of time last job node completed */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private Long endTime;
     /* hours between re-kicking */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private Long rekickTimeout;
     /* minutes max time to allocate to job before it's interrupted */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private Long maxRunTime;
     /* list of nodes and their state */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private ArrayList<JobTask> nodes;
     /* JSON configuration url -- only read at submit time if conf empty */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private String config;
     /* alerts on the job */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private List<JobAlert> alerts;
     /* URL for spawn to call on job complete. for automating workflows */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private String onComplete;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private String onError;
     /* timeout in seconds */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private int onCompleteTimeout;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private int onErrorTimeout;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private int runCount;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private long runTime;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private String command;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private String killSignal;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private boolean disabled;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private ArrayList<JobParameter> parameters;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private int backups; //Leaving in for cutover
-    @FieldConfig(codable = true)
-    private Integer hourlyBackups;
-    @FieldConfig(codable = true)
-    private Integer dailyBackups;
-    @FieldConfig(codable = true)
-    private Integer weeklyBackups;
-    @FieldConfig(codable = true)
-    private Integer monthlyBackups;
-    @FieldConfig(codable = true)
+    @FieldConfig
+    private int hourlyBackups;
+    @FieldConfig
+    private int dailyBackups;
+    @FieldConfig
+    private int weeklyBackups;
+    @FieldConfig
+    private int monthlyBackups;
+    @FieldConfig
     private int replicas;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private int readOnlyReplicas;
     // Unused
-    @FieldConfig(codable = true)
+    @FieldConfig
     private int replicationFactor;
     /* restrict replicas to hosts in current job/task space */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private boolean strictReplicas;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private boolean dontAutoBalanceMe;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private boolean dontDeleteMe;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private HashMap<String, String> properties;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private boolean hadMoreData;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private boolean wasStopped;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private int maxSimulRunning;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private String minionType;
-    @FieldConfig(codable = true)
+    @FieldConfig
     private int retries;
 
     // Query Config, eventually the job class needs to be teased apart.
-    @FieldConfig(codable = true)
+    @FieldConfig
     private JobQueryConfig queryConfig;
 
     private JobCommand submitCommand;

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/Spawn.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/Spawn.java
@@ -633,7 +633,7 @@ public class Spawn implements Codable {
                 for (String jobId : jobIds) {
                     IJob job = getJob(jobId);
                     if (job != null) {
-                        updateJobDependencies(job);
+                        updateJobDependencies(jobId);
                     }
                 }
             }
@@ -1751,8 +1751,7 @@ public class Spawn implements Codable {
     }
 
 
-    private void updateJobDependencies(IJob job) {
-        String jobId = job.getId();
+    private void updateJobDependencies(String jobId) {
         DirectedGraph<String> dependencies = spawnState.jobDependencies;
         Set<String> sources = dependencies.getSourceEdges(jobId);
         if (sources != null) {
@@ -1800,7 +1799,7 @@ public class Spawn implements Codable {
             jobLock.lock();
             try {
                 require(getJob(job.getId()) != null, "job " + job.getId() + " does not exist");
-                updateJobDependencies(job);
+                updateJobDependencies(job.getId());
                 Job oldjob = putJobInSpawnState(job);
                 // take action on trigger changes (like # replicas)
                 if (oldjob != job && reviseReplicas) {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/web/JobRequestHandler.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/web/JobRequestHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.job.web;
+
+import com.addthis.basis.kv.KVPairs;
+
+import com.addthis.hydra.job.Job;
+
+/**
+ * Handles some more complicated job API requests.
+ * 
+ * This component is intended to support spawn v1 and v2.
+ */
+public interface JobRequestHandler {
+
+    /** 
+     * Creates or updates a job.
+     * 
+     * @param kv        request parameters
+     * @param username  the user who made the request
+     * @return          the created/update job
+     * @throws IllegalArgumentException If any parameter is invalid (400 response code)
+     * @throws Exception                If any other error occurred, typically an internal one 
+     *                                  (500 response code)
+     */
+    Job createOrUpdateJob(KVPairs kv, String username) throws IllegalArgumentException, Exception;
+
+    /**
+     * Kicks the specified job if the right parameters are set. (THIS IS A LEGACY METHOD!)
+     * 
+     * This method supports spawn v1's job.submit end point which is also used for kicking job/task.
+     * Do NOT use this method in new code. 
+     * 
+     * @param kv    request parameters that may contain job/task kicking parameters
+     * @param job   the job to kick
+     * @return {@code true} if job/task is kicked; {@code false} otherwise
+     * @throws Exception if error occurred when kicking the job
+     */
+    boolean maybeKickJobOrTask(KVPairs kv, Job job) throws Exception;
+}

--- a/hydra-main/src/main/java/com/addthis/hydra/job/web/JobRequestHandlerImpl.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/web/JobRequestHandlerImpl.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.job.web;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.addthis.basis.kv.KVPair;
+import com.addthis.basis.kv.KVPairs;
+import com.addthis.basis.util.Strings;
+
+import com.addthis.hydra.job.IJob;
+import com.addthis.hydra.job.Job;
+import com.addthis.hydra.job.JobExpand;
+import com.addthis.hydra.job.JobParameter;
+import com.addthis.hydra.job.JobQueryConfig;
+import com.addthis.hydra.job.minion.Minion;
+import com.addthis.hydra.job.spawn.Spawn;
+
+public class JobRequestHandlerImpl implements JobRequestHandler {
+    
+    private final Spawn spawn;
+    
+    public JobRequestHandlerImpl(Spawn spawn) {
+        this.spawn = spawn;
+    }
+
+    @Override
+    public Job createOrUpdateJob(KVPairs kv, String username) throws IllegalArgumentException, Exception {
+        String id = KVUtils.getValue(kv, "", "id", "job");
+        String config = kv.getValue("config");
+        String expandedConfig = null;
+        String command = kv.getValue("command");
+        boolean configMayHaveChanged = true;
+        Job job;
+        if (Strings.isEmpty(id)) {
+            requireParam(!Strings.isEmpty(command), "Parameter 'command' is missing");
+            requireValidCommandParam(command);
+            requireParam(config != null, "Parameter 'config' is missing");
+            expandedConfig = tryExpandJobConfigParam(config);
+            job = spawn.createJob(
+                    kv.getValue("owner", username),
+                    kv.getIntValue("nodes", -1),
+                    Arrays.asList(Strings.splitArray(kv.getValue("hosts", ""), ",")),
+                    kv.getValue("minionType", Minion.defaultMinionType),
+                    command);
+        } else {
+            job = spawn.getJob(id);
+            requireParam(job != null, "Job " + id + " does not exist");
+            if (config == null) {
+                configMayHaveChanged = false;
+                config = spawn.getJobConfig(id);
+            }
+            expandedConfig = tryExpandJobConfigParam(config);
+            if (!Strings.isEmpty(command)) {
+                requireValidCommandParam(command);
+                job.setCommand(command);
+            }
+        }
+        updateBasicSettings(kv, job);
+        updateQueryConfig(kv, job);
+        updateJobParameters(kv, job, expandedConfig);
+        // persist update
+        // XXX When this call fails the job will be left in an inconsistent state.
+        // empirically, it happens rarely (e.g. no one sets replicas to an insanely large number).
+        // the logic is also quite involved, so to fully fix would require a major refactoring.
+        spawn.updateJob(job);
+        if (configMayHaveChanged) {
+            // only update config if it may have changed
+            spawn.setJobConfig(job.getId(), config);
+            spawn.submitConfigUpdate(job.getId(), kv.getValue("commit"));
+        }
+        return job;
+    }
+
+    private void requireParam(boolean requirement, String errorMessage) throws IllegalArgumentException {
+        if (!requirement) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+    }
+
+    private void requireValidCommandParam(String command) throws IllegalArgumentException {
+        if (spawn.getJobCommandManager().getEntity(command) == null) {
+            throw new IllegalArgumentException("Invalid command key '" + command + "'");
+        }
+    }
+
+    private String tryExpandJobConfigParam(String jobConfig) throws IllegalArgumentException {
+        try {
+            return JobExpand.macroExpand(spawn, jobConfig);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private void updateBasicSettings(KVPairs kv, IJob job) {
+        job.setOwner(kv.getValue("owner", job.getOwner()));
+        job.setPriority(kv.getIntValue("priority", job.getPriority()));
+        job.setDescription(kv.getValue("description", job.getDescription()));
+        job.setDescription(KVUtils.getValue(kv, job.getDescription(), "description", "desc"));
+        job.setOnCompleteURL(kv.getValue("onComplete", job.getOnCompleteURL()));
+        job.setOnErrorURL(kv.getValue("onError", job.getOnErrorURL()));
+        job.setOnCompleteTimeout(kv.getIntValue("onCompleteTimeout", job.getOnCompleteTimeout()));
+        job.setOnErrorTimeout(kv.getIntValue("onErrorTimeout", job.getOnErrorTimeout()));
+        job.setMaxRunTime(KVUtils.getLongValue(kv, job.getMaxRunTime(), "maxRunTime", "maxrun"));
+        job.setRekickTimeout(KVUtils.getLongValue(kv, job.getRekickTimeout(), "rekickTimeout", "rekick"));
+        job.setEnabled(KVUtils.getBooleanValue(kv, job.isEnabled(), "enable"));
+        job.setKillSignal(kv.getValue("logkill", job.getKillSignal()));
+        job.setBackups(kv.getIntValue("backups", job.getBackups()));
+        job.setDailyBackups(kv.getIntValue("dailyBackups", job.getDailyBackups()));
+        job.setHourlyBackups(kv.getIntValue("hourlyBackups", job.getHourlyBackups()));
+        job.setWeeklyBackups(kv.getIntValue("weeklyBackups", job.getWeeklyBackups()));
+        job.setMonthlyBackups(kv.getIntValue("monthlyBackups", job.getMonthlyBackups()));
+        job.setReplicas(kv.getIntValue("replicas", job.getReplicas()));
+        job.setReadOnlyReplicas(kv.getIntValue("readOnlyReplicas", job.getReadOnlyReplicas()));
+        job.setReplicationFactor(kv.getIntValue("replicationFactor", job.getReplicationFactor()));
+        job.setStomp(KVUtils.getBooleanValue(kv, job.getStomp(), "stomp"));
+        job.setDontDeleteMe(KVUtils.getBooleanValue(kv, job.getDontDeleteMe(), "dontDeleteMe"));
+        job.setDontAutoBalanceMe(KVUtils.getBooleanValue(kv, job.getDontAutoBalanceMe(), "dontAutoBalanceMe"));
+        job.setMaxSimulRunning(kv.getIntValue("maxSimulRunning", job.getMaxSimulRunning()));
+        job.setMinionType(kv.getValue("minionType", job.getMinionType()));
+        job.setRetries(kv.getIntValue("retries", job.getRetries()));
+    }
+
+    private void updateQueryConfig(KVPairs kv, IJob job) {
+        JobQueryConfig jqc;
+        if (job.getQueryConfig() != null) {
+            jqc = job.getQueryConfig().clone();
+        } else {
+            jqc = new JobQueryConfig();
+        }
+        if (kv.hasKey("qc_canQuery")) {
+            jqc.setCanQuery(KVUtils.getBooleanValue(kv, true, "qc_canQuery"));
+        }
+        if (kv.hasKey("qc_queryTraceLevel")) {
+            jqc.setQueryTraceLevel(kv.getIntValue("qc_queryTraceLevel", 0));
+        }
+        if (kv.hasKey("qc_consecutiveFailureThreshold")) {
+            jqc.setConsecutiveFailureThreshold(kv.getIntValue("qc_consecutiveFailureThreshold", 100));
+        }
+        job.setQueryConfig(jqc);
+    }
+
+    private void updateJobParameters(KVPairs kv, IJob job, String expandedConfig) {
+        // collect/merge parameters
+        Map<String, String> setParams = new LinkedHashMap<>();
+        // copy values existing in job parameters
+        if (job.getParameters() != null) {
+            // remove specified parameters
+            for (Iterator<JobParameter> jp = job.getParameters().iterator(); jp.hasNext();) {
+                JobParameter param = jp.next();
+                if (kv.hasKey("rp_" + param.getName())) {
+                    jp.remove();
+                }
+            }
+            // pull in previous values
+            for (JobParameter param : job.getParameters()) {
+                setParams.put(param.getName(), param.getValue());
+            }
+        }
+        /** set specified parameters */
+        for (KVPair kvp : kv) {
+            if (kvp.getKey().startsWith("sp_")) {
+                setParams.put(kvp.getKey().substring(3), kvp.getValue());
+            }
+        }
+
+        Map<String, JobParameter> macroParams = JobExpand.macroFindParameters(expandedConfig);
+        List<JobParameter> newparams = new ArrayList<>(macroParams.size());
+        for (JobParameter param : macroParams.values()) {
+            String name = param.getName();
+            String value = setParams.get(name);
+            param.setValue(value);
+            newparams.add(param);
+        }
+        job.setParameters(newparams);
+    }
+    
+    @Override
+    public boolean maybeKickJobOrTask(KVPairs kv, Job job) throws Exception {
+        boolean kick = KVUtils.getBooleanValue(kv, false, "spawn");
+        if (kick) {
+            boolean manual = KVUtils.getBooleanValue(kv, false, "manual");
+            int select = kv.getIntValue("select", -1);
+            if (select >= 0) {
+                spawn.startTask(job.getId(), select, true, manual, false);
+            } else {
+                spawn.startJob(job.getId(), manual);
+            }
+        }
+        return kick;
+    }
+
+}

--- a/hydra-main/src/main/java/com/addthis/hydra/job/web/KVUtils.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/web/KVUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.job.web;
+
+import java.util.Set;
+
+import com.addthis.basis.kv.KVPairs;
+
+import com.google.common.collect.Sets;
+
+public class KVUtils {
+
+    /** String values that are mapped to boolean {@code true} */
+    private static final Set<String> TRUE_STR_VALUES = Sets.newHashSet("true", "1");
+
+    public static String getValue(KVPairs kv, String[] keys) {
+        for (String key : keys) {
+            if (kv.hasKey(key)) {
+                String v = kv.getValue(key);
+                if (v != null) {
+                    return v;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static String getValue(KVPairs kv, String defaultValue, String... keys) {
+        String v = getValue(kv, keys);
+        return v == null ? defaultValue : v;
+    }
+
+    public static Long getLongValue(KVPairs kv, Long defaultValue, String... keys) {
+        String v = getValue(kv, keys);
+        try {
+            return v == null ? defaultValue : Long.parseLong(v);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static boolean getBooleanValue(KVPairs kv, boolean defaultValue, String... keys) {
+        String v = getValue(kv, keys);
+        return v == null ? defaultValue : TRUE_STR_VALUES.contains(v);
+    }
+}

--- a/hydra-main/src/main/java/com/addthis/hydra/job/web/SpawnService.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/web/SpawnService.java
@@ -69,7 +69,7 @@ public class SpawnService {
 
         //instantiate resources
         ListenResource listenResource = new ListenResource(spawn, pollTimeout);
-        JobsResource jobsResource = new JobsResource(spawn);
+        JobsResource jobsResource = new JobsResource(spawn, new JobRequestHandlerImpl(spawn));
         MacroResource macroResource = new MacroResource(spawn.getJobMacroManager());
         CommandResource commandResource = new CommandResource(spawn.getJobCommandManager());
         TaskResource taskResource = new TaskResource(spawn);

--- a/hydra-main/src/test/java/com/addthis/hydra/job/web/JobRequestHandlerImplTest.java
+++ b/hydra-main/src/test/java/com/addthis/hydra/job/web/JobRequestHandlerImplTest.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.job.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyCollectionOf;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import com.addthis.basis.kv.KVPairs;
+import com.addthis.basis.util.Strings;
+
+import com.addthis.hydra.job.Job;
+import com.addthis.hydra.job.JobParameter;
+import com.addthis.hydra.job.entity.JobCommand;
+import com.addthis.hydra.job.entity.JobCommandManager;
+import com.addthis.hydra.job.spawn.Spawn;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class JobRequestHandlerImplTest {
+
+    private Spawn spawn;
+    private JobCommandManager jobCommandManager;
+    private JobRequestHandlerImpl impl;
+    private String username = "megatron";
+    private KVPairs kv;
+
+    @Before
+    public void setUp() {
+        // mocks and stubs
+        spawn = mock(Spawn.class);
+        jobCommandManager = mock(JobCommandManager.class);
+        when(spawn.getJobCommandManager()).thenReturn(jobCommandManager);
+        when(jobCommandManager.getEntity("default-task")).thenReturn(new JobCommand());
+
+        impl = new JobRequestHandlerImpl(spawn);
+        kv = new KVPairs();
+    }
+
+    @Test
+    public void createJob() throws Exception {
+        // stub spawn calls
+        Job job = new Job("new_job_id", "megatron");
+        when(spawn.createJob("megatron", -1, Collections.<String> emptyList(), "default", "default-task")).thenReturn(job);
+        when(spawn.getJob("new_job_id")).thenReturn(job);
+
+        kv.add("config", "my job config");
+        kv.add("command", "default-task");
+        assertSame("returned job", job, impl.createOrUpdateJob(kv, username));
+
+        // verify spawn calls
+        verify(spawn).updateJob(job);
+        verify(spawn).setJobConfig("new_job_id", "my job config");
+        verify(spawn).submitConfigUpdate("new_job_id", null);
+    }
+
+    @Test
+    public void createJob_MissingCommand() throws Exception {
+        kv.add("config", "my job config");
+        callAndVerifyBadRequest();
+        verifyNoSpawnCreateJobCall();
+    }
+
+    @Test
+    public void createJob_InvalidCommand() throws Exception {
+        kv.add("command", "bogus-task");
+        kv.add("config", "my job config");
+        callAndVerifyBadRequest();
+        verifyNoSpawnCreateJobCall();
+    }
+
+    @Test
+    public void createJob_MissingConfig() throws Exception {
+        kv.add("command", "default-task");
+        callAndVerifyBadRequest();
+        verifyNoSpawnCreateJobCall();
+    }
+
+    @Test
+    public void createJob_ConfigTooLarge() throws Exception {
+        kv.add("command", "default-task");
+        kv.add("config", Strings.repeat('x', 1_000_001));
+        callAndVerifyBadRequest();
+        verifyNoSpawnCreateJobCall();
+    }
+
+    @Test
+    public void updateJob() throws Exception {
+        // stub spawn calls
+        Job job = new Job("existing_job_id", "megatron");
+        job.setCommand("old-task");
+        when(spawn.getJob("existing_job_id")).thenReturn(job);
+
+        kv.add("id", "existing_job_id");
+        kv.add("config", "my job config");
+        kv.add("command", "default-task");
+        assertSame("returned job", job, impl.createOrUpdateJob(kv, username));
+        assertEquals("command is updated", "default-task", job.getCommand());
+
+        verifyNoSpawnCreateJobCall();
+        // verify other spawn calls
+        verify(spawn).updateJob(job);
+        verify(spawn).setJobConfig("existing_job_id", "my job config");
+        verify(spawn).submitConfigUpdate("existing_job_id", null);
+    }
+
+    @Test
+    public void updateJob_InvalidJobId() throws Exception {
+        kv.add("id", "bogus_job_id");
+        kv.add("config", "my job config");
+        kv.add("command", "default-task");
+        callAndVerifyBadRequest();
+
+        verify(spawn, never()).updateJob(any(Job.class));
+    }
+
+    /** If command is not specified when updating a job, it should remain unchanged */
+    @Test
+    public void updateJob_MissingCommand() throws Exception {
+        // stub spawn calls
+        Job job = new Job("existing_job_id", "megatron");
+        job.setCommand("old-task");
+        when(spawn.getJob("existing_job_id")).thenReturn(job);
+
+        kv.add("id", "existing_job_id");
+        kv.add("config", "my job config");
+        assertSame("returned job", job, impl.createOrUpdateJob(kv, username));
+        assertEquals("command is unchanged", "old-task", job.getCommand());
+    }
+
+    /** If specified command is invalid when updating a job, job should remain unchanged */
+    @Test
+    public void updateJob_InvalidCommand() throws Exception {
+        // stub spawn calls
+        Job job = new Job("existing_job_id", "megatron");
+        job.setCommand("old-task");
+        when(spawn.getJob("existing_job_id")).thenReturn(job);
+
+        kv.add("id", "existing_job_id");
+        kv.add("config", "my job config");
+        kv.add("command", "bogus-task");
+        callAndVerifyBadRequest();
+
+        assertEquals("command is unchanged", "old-task", job.getCommand());
+
+        verify(spawn, never()).updateJob(job);
+    }
+
+    /** If config is not specified when updating a job, it should remain unchanged */
+    @Test
+    public void updateJob_MissingConfig() throws Exception {
+        // stub spawn calls
+        Job job = new Job("existing_job_id", "megatron");
+        when(spawn.getJob("existing_job_id")).thenReturn(job);
+        when(spawn.getJobConfig("existing_job_id")).thenReturn("old job config");
+
+        kv.add("id", "existing_job_id");
+        assertSame("returned job", job, impl.createOrUpdateJob(kv, username));
+
+        verify(spawn, never()).setJobConfig(anyString(), anyString());
+        verify(spawn, never()).submitConfigUpdate(anyString(), anyString());
+    }
+
+    /**
+     * Only job parameters in the job config should be added/updated; those that are not should be 
+     * removed/ignored
+     */
+    @Test
+    public void updateJobParameters() throws Exception {
+        // stub spawn calls
+        Job job = new Job("existing_job_id", "megatron");
+        job.setParameters(Lists.newArrayList(
+                new JobParameter("start-date", "140908", null),
+                new JobParameter("end-date", "140908", null)));
+        when(spawn.getJob("existing_job_id")).thenReturn(job);
+
+        kv.add("id", "existing_job_id");
+        // new job config removes 'end-date' and adds 'foo'
+        kv.add("config", "%[start-date]% %[foo]%");
+        kv.add("command", "default-task");
+        kv.add("sp_start-date", "140908");
+        kv.add("sp_end-date", "140908"); // should be removed
+        kv.add("sp_foo", "foo");
+        kv.add("sp_bar", "bar"); // should be ignored
+        assertSame("returned job", job, impl.createOrUpdateJob(kv, username));
+        assertEquals("# of parameters", 2, job.getParameters().size());
+        JobParameter foo = null;
+        JobParameter startDate = null;
+        for (JobParameter jp : job.getParameters()) {
+            if ("start-date".equals(jp.getName())) {
+                startDate = jp;
+            } else if ("foo".equals(jp.getName())) {
+                foo = jp;
+            }
+        }
+        assertNotNull("parameter 'start-date' found", startDate);
+        assertEquals("parameter 'start-date' value", "140908", startDate.getValue());
+        assertNotNull("parameter 'foo' found", foo);
+        assertEquals("parameter 'foo' value", "foo", foo.getValue());
+    }
+
+    private void verifyNoSpawnCreateJobCall() throws Exception {
+        verify(spawn, never()).createJob(anyString(), anyInt(), anyCollectionOf(String.class), anyString(), anyString());
+    }
+
+    private void callAndVerifyBadRequest() throws Exception {
+        try {
+            impl.createOrUpdateJob(kv, username);
+            fail("IllegalArgumentException expected but was not thrown");
+        } catch (IllegalArgumentException e) {
+            // GOOD!
+        }
+    }
+}

--- a/hydra-main/src/test/java/com/addthis/hydra/job/web/KVUtilsTest.java
+++ b/hydra-main/src/test/java/com/addthis/hydra/job/web/KVUtilsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.job.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.addthis.basis.kv.KVPairs;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class KVUtilsTest {
+
+    private KVPairs kv;
+
+    @Before
+    public void setUp() {
+        kv = new KVPairs();
+    }
+
+    @Test
+    public void getValue() {
+        kv.add("foo", "bar");
+        kv.add("toto", "tata");
+        assertEquals("primary key", "bar", KVUtils.getValue(kv, "default", "foo", "toto"));
+        assertEquals("secondary key", "tata", KVUtils.getValue(kv, "default", "bogus", "toto"));
+        assertEquals("default value", "default", KVUtils.getValue(kv, "default", "bogus", "bogus_too"));
+    }
+
+    @Test
+    public void getLongValue() {
+        kv.add("foo", "1");
+        kv.add("toto", "2");
+        assertEquals("primary key", new Long(1), KVUtils.getLongValue(kv, 0L, "foo", "toto"));
+        assertEquals("secondary key", new Long(2), KVUtils.getLongValue(kv, 0L, "bogus", "toto"));
+        assertEquals("default value", new Long(0), KVUtils.getLongValue(kv, 0L, "bogus", "bogus_too"));
+    }
+
+    @Test
+    public void getBooleanValue() {
+        kv.add("foo", "true");
+        kv.add("toto", "0");
+        assertTrue("primary key", KVUtils.getBooleanValue(kv, false, "foo", "toto"));
+        assertFalse("secondary key", KVUtils.getBooleanValue(kv, true, "bogus", "toto"));
+        assertTrue("default value", KVUtils.getBooleanValue(kv, true, "bogus", "bogus_too"));
+    }
+
+}

--- a/hydra-main/src/test/java/com/addthis/hydra/job/web/resources/JobsResourceTest.java
+++ b/hydra-main/src/test/java/com/addthis/hydra/job/web/resources/JobsResourceTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.job.web.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import javax.ws.rs.core.Response;
+
+import com.addthis.basis.kv.KVPairs;
+
+import com.addthis.hydra.job.Job;
+import com.addthis.hydra.job.spawn.Spawn;
+import com.addthis.hydra.job.web.JobRequestHandler;
+import com.addthis.hydra.job.web.jersey.User;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class JobsResourceTest {
+
+    private Spawn spawn;
+    private JobRequestHandler requestHandler;
+    private JobsResource resource;
+    private User user = new User("megatron", "whatever");
+    private KVPairs kv;
+
+    @Before
+    public void setUp() {
+        // mocks and stubs
+        spawn = mock(Spawn.class);
+        requestHandler = mock(JobRequestHandler.class);
+
+        resource = new JobsResource(spawn, requestHandler);
+        kv = new KVPairs();
+    }
+
+    @Test
+    public void saveJob() throws Exception {
+        // stub spawn calls
+        Job job = new Job("new_job_id", "megatron");
+        when(requestHandler.createOrUpdateJob(kv, "megatron")).thenReturn(job);
+        Response response = resource.saveJob(kv, user);
+        assertEquals(200, response.getStatus());
+        verifyZeroInteractions(spawn);
+    }
+
+    @Test
+    public void saveJob_BadParam() throws Exception {
+        when(requestHandler.createOrUpdateJob(kv, "megatron")).thenThrow(new IllegalArgumentException("bad param"));
+        Response response = resource.saveJob(kv, user);
+        assertEquals(400, response.getStatus());
+        verifyZeroInteractions(spawn);
+    }
+
+    @Test
+    public void saveJob_InternalError() throws Exception {
+        when(requestHandler.createOrUpdateJob(kv, "megatron")).thenThrow(new Exception("internal error"));
+        Response response = resource.saveJob(kv, user);
+        assertEquals(500, response.getStatus());
+        verifyZeroInteractions(spawn);
+    }
+}

--- a/hydra-main/web/spawn/index.html
+++ b/hydra-main/web/spawn/index.html
@@ -313,7 +313,7 @@
 					<tr>
 						<th>event</th>
 						<td>
-							<label>success</label> <input id="form_job_onComplete" name="onDone" size=31>
+							<label>success</label> <input id="form_job_onComplete" name="onComplete" size=31>
 							<label>fail</label> <input id="form_job_onError" name="onError" size=31>
 							<label>kill match</label> <input id="form_job_logkill" name="logkill" size=31>
 						</td>

--- a/hydra-main/web/spawn2/js/modules/jobs.js
+++ b/hydra-main/web/spawn2/js/modules/jobs.js
@@ -295,9 +295,9 @@ function(
             if(!_.isEmpty(this.commit)){
                 data.commit=this.commit;
             }
-            var url = "/job/submit?spawn=0&manual=1";
+            var url = "/job/save";
             if(!this.isNew()){
-                url+="&id="+this.id;
+                url+="?id="+this.id;
             }
             return $.ajax({
                 url: url,


### PR DESCRIPTION
spawn v1 and v2 use the same code to create/update jobs.
spawn v2 uses job/save instead of job/submit to save jobs. 
