### PR TITLE
Bug fix for 'reservoir' '$' query notation.

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataReservoir.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataReservoir.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import java.math.RoundingMode;
+import java.util.regex.Pattern;
 
 import com.addthis.basis.util.ClosableIterator;
 import com.addthis.basis.util.Varint;
@@ -95,10 +96,11 @@ public class DataReservoir extends TreeNodeData<DataReservoir.Config> implements
      * {@code /delta:+hits/measurement:+hits/mean:+hits/stddev:+hits/mode:+hits/percentile:+hits}.
      *
      * <p>The data attachment can also be queried with the notation
-     * {@code /$name=epoch=N~percentile=N~obs=N~min=N~mode=modelfit}.
-     * The query parameters are identical to those from the previous paragraph.
-     * The output returned is a value array with six elements. The contents of the
-     * array are ["delta", "measurement", "mean", "stddev", "mode", "percentile"].
+     * {@code /$name=epoch||N~percentile||N~obs||N~min||N~mode||modelfit}.
+     * The query parameters are identical to those from the previous paragraph
+     * with the exception that "=" separator has been replaced with the "||" separator
+     * (sideways equals?). The output returned is a value array with six elements.
+     * The contents of the array are ["delta", "measurement", "mean", "stddev", "mode", "percentile"].
      *
      * @user-reference
      * @hydra-name reservoir
@@ -378,7 +380,7 @@ public class DataReservoir extends TreeNodeData<DataReservoir.Config> implements
         }
     }
 
-    private ValueObject generateValueObject(String key) {
+    private ValueObject generateValueObject(String key, String separator) {
         long targetEpoch = -1;
         int numObservations = -1;
         double sigma = Double.POSITIVE_INFINITY;
@@ -390,9 +392,9 @@ public class DataReservoir extends TreeNodeData<DataReservoir.Config> implements
         if (key == null) {
             return null;
         }
-        String[] kvpairs = key.split("~");
+        String[] kvpairs = key.split(Pattern.quote("~"));
         for(String kvpair : kvpairs) {
-            String[] kv = kvpair.split("=");
+            String[] kv = kvpair.split(Pattern.quote(separator));
             if (kv.length == 2) {
                 String kvkey = kv[0];
                 String kvvalue = kv[1];
@@ -467,7 +469,7 @@ public class DataReservoir extends TreeNodeData<DataReservoir.Config> implements
         if (key == null) {
             return null;
         }
-        ValueObject value = generateValueObject(key);
+        ValueObject value = generateValueObject(key, "||");
         if (value instanceof DataReservoirValue) {
             DataReservoirValue dataReservoirValue = (DataReservoirValue) value;
             value = dataReservoirValue.setDoubleToLongClone(true).setRawClone(false);
@@ -480,7 +482,7 @@ public class DataReservoir extends TreeNodeData<DataReservoir.Config> implements
         if (key == null) {
             return null;
         }
-        DataReservoirValue value = (DataReservoirValue) generateValueObject(key);
+        DataReservoirValue value = (DataReservoirValue) generateValueObject(key, "=");
         return computeResult(value);
     }
 

--- a/hydra-data/src/test/java/com/addthis/hydra/data/tree/prop/DataReservoirTest.java
+++ b/hydra-data/src/test/java/com/addthis/hydra/data/tree/prop/DataReservoirTest.java
@@ -201,7 +201,7 @@ public class DataReservoirTest {
         reservoir.updateReservoir(2, 4, 12);
         reservoir.updateReservoir(3, 4, 4);
         reservoir.updateReservoir(4, 4, 100);
-        ValueArray result = reservoir.getValue("epoch=4~sigma=2.0~obs=3").asArray();
+        ValueArray result = reservoir.getValue("epoch||4~sigma||2.0~obs||3").asArray();
         assertEquals(5, result.size());
         assertEquals(86, DoubleMath.roundToLong(result.get(0).asDouble().getDouble(), RoundingMode.HALF_UP));
         assertEquals(100, result.get(1).asLong().getLong());
@@ -210,12 +210,12 @@ public class DataReservoirTest {
         assertEquals(14, result.get(4).asLong().getLong());
 
         // test mode "get"
-        assertEquals(0, reservoir.getValue("mode=get~epoch=0").asLong().getLong());
-        assertEquals(4, reservoir.getValue("mode=get~epoch=1").asLong().getLong());
-        assertEquals(12, reservoir.getValue("mode=get~epoch=2").asLong().getLong());
-        assertEquals(4, reservoir.getValue("mode=get~epoch=3").asLong().getLong());
-        assertEquals(100, reservoir.getValue("mode=get~epoch=4").asLong().getLong());
-        assertEquals(0, reservoir.getValue("mode=get~epoch=5").asLong().getLong());
+        assertEquals(0, reservoir.getValue("mode||get~epoch||0").asLong().getLong());
+        assertEquals(4, reservoir.getValue("mode||get~epoch||1").asLong().getLong());
+        assertEquals(12, reservoir.getValue("mode||get~epoch||2").asLong().getLong());
+        assertEquals(4, reservoir.getValue("mode||get~epoch||3").asLong().getLong());
+        assertEquals(100, reservoir.getValue("mode||get~epoch||4").asLong().getLong());
+        assertEquals(0, reservoir.getValue("mode||get~epoch||5").asLong().getLong());
     }
 
     @Test
@@ -225,7 +225,7 @@ public class DataReservoirTest {
         reservoir.updateReservoir(2, 4, 12);
         reservoir.updateReservoir(3, 4, 4);
         reservoir.updateReservoir(4, 4, 100);
-        DataReservoir.DataReservoirValue original = (DataReservoir.DataReservoirValue) reservoir.getValue("epoch=4~sigma=2.0~obs=3");
+        DataReservoir.DataReservoirValue original = (DataReservoir.DataReservoirValue) reservoir.getValue("epoch||4~sigma||2.0~obs||3");
         DataReservoir.DataReservoirValue translated = new DataReservoir.DataReservoirValue();
         translated.setValues(original.asMap());
         ValueArray result = translated.asArray();
@@ -237,12 +237,12 @@ public class DataReservoirTest {
         assertEquals(14, result.get(4).asLong().getLong());
 
         // test mode "get"
-        assertEquals(0, reservoir.getValue("mode=get~epoch=0").asLong().getLong());
-        assertEquals(4, reservoir.getValue("mode=get~epoch=1").asLong().getLong());
-        assertEquals(12, reservoir.getValue("mode=get~epoch=2").asLong().getLong());
-        assertEquals(4, reservoir.getValue("mode=get~epoch=3").asLong().getLong());
-        assertEquals(100, reservoir.getValue("mode=get~epoch=4").asLong().getLong());
-        assertEquals(0, reservoir.getValue("mode=get~epoch=5").asLong().getLong());
+        assertEquals(0, reservoir.getValue("mode||get~epoch||0").asLong().getLong());
+        assertEquals(4, reservoir.getValue("mode||get~epoch||1").asLong().getLong());
+        assertEquals(12, reservoir.getValue("mode||get~epoch||2").asLong().getLong());
+        assertEquals(4, reservoir.getValue("mode||get~epoch||3").asLong().getLong());
+        assertEquals(100, reservoir.getValue("mode||get~epoch||4").asLong().getLong());
+        assertEquals(0, reservoir.getValue("mode||get~epoch||5").asLong().getLong());
     }
 
 


### PR DESCRIPTION
Can someone take a look over this fix to the '$' queries of the reservoir data attachment? I thought I had tested that notation but it turns out I wrote a unit test that doesn't go through the entire parsing pipeline. I failed to notice that the '=' character is a reserved character in the '$' query notation. It is used to constrain the result of the query, ie. '<', '=', or '>' can be used. I've fixed the '$' notation in the reservoir data attachment to use '||' instead of '='. Any suggestions on an alternative notation other than '||' is solicited. We can't use '~' as that is another kind of separator and I want to be relatively consistent between the '%' and '$' notation of this data attachment. Plus we use '~' in other places to mean things that are not equality.
