### PR TITLE
do not swallow exceptions for disk checks

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/util/WriteableDiskCheck.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/util/WriteableDiskCheck.java
@@ -18,7 +18,12 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class WriteableDiskCheck extends MeteredHealthCheck {
+
+    private static final Logger log = LoggerFactory.getLogger(WriteableDiskCheck.class);
 
     private List<File> checkedFiles;
 
@@ -38,6 +43,7 @@ public class WriteableDiskCheck extends MeteredHealthCheck {
                 }
             } catch (Exception e) {
                 // keep trying files until one succeeds, or all fail
+                log.warn("check failed for {}", file, e);
             }
         }
         return false;


### PR DESCRIPTION
`WriteableDiskCheck` can fail for a variety of reasons besides the
underlying `open` or `utimensat` syscalls failing.  For example:
another directory (such as `/bin` or `/lib`) can not be read, a
shared library could be missing, a ulimit reached, or a bug in the
check itself.  To allow those situations to be debugged we need to
exception.

NOTE: Log is at WARN to preserve 'at least one path must be writeable'
semantics.  However, those semantics are nuts and should probably be
changed to 'all paths must be writeable'.