### PR TITLE
Filter initialization is now explicit. Ref T51853.

### DIFF
--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilter.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilter.java
@@ -34,11 +34,6 @@ import org.slf4j.LoggerFactory;
 @Pluggable("bundle-filter")
 public abstract class BundleFilter implements Codable {
 
-    private static final Logger log = LoggerFactory.getLogger(BundleFilter.class);
-
-    private AtomicBoolean init    = new AtomicBoolean(false);
-    private AtomicBoolean initing = new AtomicBoolean(false);
-
     /**
      * @param bundle      row/line/packet bundle
      * @param bindTargets use the same object or re-binding will occur
@@ -59,32 +54,9 @@ public abstract class BundleFilter implements Codable {
         return boundFields;
     }
 
-    public final void initOnceOnly() {
-        if (!init.get()) {
-            if (initing.compareAndSet(false, true)) {
-                try {
-                    initialize();
-                } finally {
-                    init.set(true);
-                    initing.set(false);
-                }
-            } else {
-                while (initing.get()) {
-                    Thread.yield();
-                }
-            }
-        }
-    }
-
-    /* most won't use it, but all must implement */
-    public abstract void initialize();
+    public abstract void open();
 
     /* returns true of chain should continue, false to break */
-    public abstract boolean filterExec(Bundle row);
+    public abstract boolean filter(Bundle row);
 
-    /* wrapper that calls init once only */
-    public final boolean filter(final Bundle row) {
-        initOnceOnly();
-        return filterExec(row);
-    }
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterAppend.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterAppend.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleField;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.util.ValueUtil;
 import com.addthis.bundle.value.ValueArray;
 import com.addthis.bundle.value.ValueFactory;
@@ -68,7 +69,7 @@ public class BundleFilterAppend extends BundleFilter {
         return this;
     }
 
-    public BundleFilterAppend setToField(String field) {
+    public BundleFilterAppend setToField(AutoField field) {
         this.to = field;
         return this;
     }
@@ -91,14 +92,14 @@ public class BundleFilterAppend extends BundleFilter {
     /**
      * Both the start of the array and the destination field. Required field.
      */
-    @FieldConfig(codable = true, required = true)
-    private String to;
+    @FieldConfig(required = true)
+    private AutoField to;
 
     /**
      * A field to append at the end of the array.
      */
     @FieldConfig(codable = true)
-    private String from;
+    private AutoField from;
 
     /**
      * A list of values to append in between the 'to' and 'from' fields.
@@ -131,11 +132,11 @@ public class BundleFilterAppend extends BundleFilter {
     @FieldConfig(codable = true)
     private int size = 5;
 
-    private String[] fields;
-
     @Override
-    public void initialize() {
-        fields = new String[]{to, from};
+    public void open() {
+        if (filter != null) {
+            filter.open();
+        }
     }
 
     private boolean contains(ValueArray arr, ValueObject obj) {
@@ -149,9 +150,8 @@ public class BundleFilterAppend extends BundleFilter {
     }
 
     @Override
-    public boolean filterExec(Bundle bundle) {
-        BundleField[] bound = getBindings(bundle, fields);
-        ValueObject toVal = bundle.getValue(bound[0]);
+    public boolean filter(Bundle bundle) {
+        ValueObject toVal = to.getValue(bundle);
         ValueArray arr = null;
         if (toVal == null) {
             if (nullFail) {
@@ -176,7 +176,7 @@ public class BundleFilterAppend extends BundleFilter {
         }
         // append from if set
         if (from != null) {
-            ValueObject fromVal = bundle.getValue(bound[1]);
+            ValueObject fromVal = from.getValue(bundle);
             if (filter != null) {
                 fromVal = filter.filter(fromVal);
             }
@@ -192,7 +192,7 @@ public class BundleFilterAppend extends BundleFilter {
                 }
             }
         }
-        bundle.setValue(bound[0], arr);
+        to.setValue(bundle, arr);
         return true;
     }
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterChain.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterChain.java
@@ -68,16 +68,16 @@ public class BundleFilterChain extends BundleFilter {
     private final AtomicLong bundleCounter = new AtomicLong();
 
     @Override
-    public void initialize() {
+    public void open() {
         for (BundleFilter f : filter) {
-            f.initOnceOnly();
+            f.open();
         }
     }
 
     @Override
-    public boolean filterExec(Bundle row) {
+    public boolean filter(Bundle row) {
         for (BundleFilter f : filter) {
-            if (!f.filterExec(row) && failStop) {
+            if (!f.filter(row) && failStop) {
                 if (debug && bundleCounter.getAndIncrement() < debugMaxBundles) {
                     log.warn("fail @ " + CodecJSON.tryEncodeString(f, "UNKNOWN") + " with " +
                              BundlePrinter.printBundle(row));

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterClear.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterClear.java
@@ -56,10 +56,14 @@ public class BundleFilterClear extends BundleFilter {
     @FieldConfig private boolean removes = false;
 
     @Override
-    public void initialize() { }
+    public void open() {
+        if (filter != null) {
+            filter.open();
+        }
+    }
 
     @Override
-    public boolean filterExec(Bundle bundle) {
+    public boolean filter(Bundle bundle) {
         ValueObject val = field.getValue(bundle);
         if (filter != null) {
             val = filter.filter(val);

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterConcat.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterConcat.java
@@ -47,10 +47,10 @@ public class BundleFilterConcat extends BundleFilter {
     @FieldConfig private String join;
 
     @Override
-    public void initialize() { }
+    public void open() { }
 
     @Override
-    public boolean filterExec(Bundle bundle) {
+    public boolean filter(Bundle bundle) {
         StringBuilder sb = new StringBuilder();
         boolean appendJoin = false;
         for (AutoField field : in) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterCondition.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterCondition.java
@@ -42,7 +42,7 @@ public class BundleFilterCondition extends BundleFilter {
 
     /**
      * The bundle filter to execute when {@link #ifCondition ifCondition} returns true. This
-     * field is required.
+     * field is optional.
      */
     @FieldConfig(codable = true)
     BundleFilter ifDo;
@@ -73,28 +73,28 @@ public class BundleFilterCondition extends BundleFilter {
     }
 
     @Override
-    public void initialize() {
-        ifCondition.initOnceOnly();
+    public void open() {
+        ifCondition.open();
         if (ifDo != null) {
-            ifDo.initOnceOnly();
+            ifDo.open();
         }
         if (elseDo != null) {
-            elseDo.initOnceOnly();
+            elseDo.open();
         }
     }
 
     @Override
-    public boolean filterExec(Bundle row) {
+    public boolean filter(Bundle row) {
         boolean returnValue = true;
         if (row != null) {
-            if (ifCondition != null && ifCondition.filterExec(row)) {
+            if (ifCondition != null && ifCondition.filter(row)) {
                 if (ifDo != null) {
-                    boolean result = ifDo.filterExec(row);
+                    boolean result = ifDo.filter(row);
                     returnValue = returnFilter ? result : returnValue;
                 }
             } else {
                 if (elseDo != null) {
-                    boolean result = elseDo.filterExec(row);
+                    boolean result = elseDo.filter(row);
                     returnValue = returnFilter ? result : returnValue;
                 }
             }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterContains.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterContains.java
@@ -15,6 +15,7 @@ package com.addthis.hydra.data.filter.bundle;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleField;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.util.ValueUtil;
 import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
@@ -45,52 +46,47 @@ public class BundleFilterContains extends BundleFilter {
     /**
      * The input field to test. This field is required.
      */
-    @FieldConfig(codable = true, required = true)
-    private String field;
+    @FieldConfig(required = true)
+    private AutoField field;
 
     /**
      * An array of strings to test against the input field.
      */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private String[] value;
 
     /**
      * The target field to test against the input field.
      */
-    @FieldConfig(codable = true)
-    private String from;
+    @FieldConfig
+    private AutoField from;
 
     /**
      * If true then return the negation of the contains operation. Default is false.
      */
-    @FieldConfig(codable = true)
+    @FieldConfig
     private boolean not;
 
     // Cache the value filter if-and-only-if the 'from' field is null.
     private ValueFilterContains filter;
 
-    private String[] fields;
-
     @Override
-    public void initialize() {
-        fields = new String[]{field, from};
-
+    public void open() {
         if (from == null && value != null) {
             filter = new ValueFilterContains().setValues(value);
-            filter.requireSetup();
+            filter.open();
         }
     }
 
     @Override
-    public boolean filterExec(Bundle row) {
+    public boolean filter(Bundle row) {
         if (row == null) {
             return not;
         }
-        BundleField[] bound = getBindings(row, fields);
-        ValueObject target = row.getValue(bound[0]);
+        ValueObject target = field.getValue(row);
         if (from != null) {
             String fieldString = target.asString().asNative();
-            String fromString = ValueUtil.asNativeString(row.getValue(bound[1]));
+            String fromString = ValueUtil.asNativeString(from.getValue(row));
             boolean match = fieldString.contains(fromString);
             return not ? !match : match;
         } else if (filter != null) {
@@ -101,12 +97,12 @@ public class BundleFilterContains extends BundleFilter {
         }
     }
 
-    BundleFilterContains setField(String field) {
+    BundleFilterContains setField(AutoField field) {
         this.field = field;
         return this;
     }
 
-    BundleFilterContains setFrom(String from) {
+    BundleFilterContains setFrom(AutoField from) {
         this.from = from;
         return this;
     }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterContains.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterContains.java
@@ -21,6 +21,9 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.hydra.data.filter.value.ValueFilterContains;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 
 /**
  * This {@link com.addthis.hydra.data.filter.bundle.BundleFilter BundleFilter} <span class="hydra-summary">tests if the input contains the target value</span>.
@@ -46,34 +49,45 @@ public class BundleFilterContains extends BundleFilter {
     /**
      * The input field to test. This field is required.
      */
-    @FieldConfig(required = true)
-    private AutoField field;
+    final private AutoField field;
 
     /**
      * An array of strings to test against the input field.
      */
-    @FieldConfig
-    private String[] value;
+    final private String[] value;
 
     /**
      * The target field to test against the input field.
      */
-    @FieldConfig
-    private AutoField from;
+    final private AutoField from;
 
     /**
      * If true then return the negation of the contains operation. Default is false.
      */
-    @FieldConfig
-    private boolean not;
+    final private boolean not;
 
     // Cache the value filter if-and-only-if the 'from' field is null.
-    private ValueFilterContains filter;
+    final private ValueFilterContains filter;
+
+    @JsonCreator
+    public BundleFilterContains(@JsonProperty("field") AutoField field,
+                                @JsonProperty("value") String[] value,
+                                @JsonProperty("from") AutoField from,
+                                @JsonProperty("not") boolean not) {
+        this.field = field;
+        this.value = value;
+        this.from = from;
+        this.not = not;
+        if (from == null && value != null) {
+            filter = new ValueFilterContains(value, null, false, false);
+        } else {
+            filter = null;
+        }
+    }
 
     @Override
     public void open() {
-        if (from == null && value != null) {
-            filter = new ValueFilterContains().setValues(value);
+        if (filter != null) {
             filter.open();
         }
     }
@@ -95,21 +109,6 @@ public class BundleFilterContains extends BundleFilter {
         } else {
             return not;
         }
-    }
-
-    BundleFilterContains setField(AutoField field) {
-        this.field = field;
-        return this;
-    }
-
-    BundleFilterContains setFrom(AutoField from) {
-        this.from = from;
-        return this;
-    }
-
-    BundleFilterContains setValue(String[] value) {
-        this.value = value;
-        return this;
     }
 
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterDebugPrint.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterDebugPrint.java
@@ -83,8 +83,7 @@ public class BundleFilterDebugPrint extends BundleFilter {
     private boolean enableCacheOutput = false;
 
     @Override
-    public void initialize() {
-    }
+    public void open() { }
 
     BundleFilterDebugPrint enableCacheOutput() {
         this.enableCacheOutput = true;
@@ -117,7 +116,7 @@ public class BundleFilterDebugPrint extends BundleFilter {
     }
 
     @Override
-    public boolean filterExec(Bundle bundle) {
+    public boolean filter(Bundle bundle) {
         boolean print = (bundleCounter.getAndIncrement() < maxBundles) || testBundleTimer();
         if (print) {
             String bundleString = formatBundle(bundle);

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterEquals.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterEquals.java
@@ -15,6 +15,7 @@ package com.addthis.hydra.data.filter.bundle;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleField;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
@@ -44,13 +45,13 @@ public class BundleFilterEquals extends BundleFilter {
      * the left hand field value
      */
     @FieldConfig(codable = true, required = true)
-    private String left;
+    private AutoField left;
 
     /**
      * The right hand field
      */
     @FieldConfig(codable = true, required = true)
-    private String right;
+    private AutoField right;
 
     /**
      * inverts behavior of filter
@@ -58,20 +59,13 @@ public class BundleFilterEquals extends BundleFilter {
     @FieldConfig(codable = true)
     private boolean not;
 
-    String[] fields;
+    @Override
+    public void open() { }
 
     @Override
-    public void initialize() {
-        fields = new String[2];
-        fields[0] = left;
-        fields[1] = right;
-    }
-
-    @Override
-    public boolean filterExec(Bundle bundle) {
-        BundleField[] bound = getBindings(bundle, fields);
-        ValueObject lv = bundle.getValue(bound[0]);
-        ValueObject rv = bundle.getValue(bound[1]);
+    public boolean filter(Bundle bundle) {
+        ValueObject lv = left.getValue(bundle);
+        ValueObject rv = right.getValue(bundle);
         if (lv == null && rv == null) {
             return !not;
         } else if (lv == null || rv == null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterEvalJava.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterEvalJava.java
@@ -148,9 +148,9 @@ public class BundleFilterEvalJava extends BundleFilter {
     }
 
     @Override
-    public boolean filterExec(Bundle row) {
+    public boolean filter(Bundle row) {
         if (constructedFilter != null) {
-            return constructedFilter.filterExec(row);
+            return constructedFilter.filter(row);
         } else {
             return false;
         }
@@ -214,6 +214,7 @@ public class BundleFilterEvalJava extends BundleFilter {
                 log.warn("\n" + classDeclString);
                 throw new IllegalStateException(msg);
             }
+            filter.open();
             return filter;
         } finally {
             compiler.cleanupFiles(className);
@@ -363,7 +364,7 @@ public class BundleFilterEvalJava extends BundleFilter {
 
 
     @Override
-    public void initialize() {
+    public void open() {
         typeBundle = false;
         for (int i = 0; i < types.length; i++) {
             if (types[i].equals(InputType.BUNDLE_RAW)) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterField.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterField.java
@@ -62,10 +62,14 @@ public class BundleFilterField extends BundleFilter {
     /** The value to return when nullFail is true and the value filter output is null. Default is false. */
     @FieldConfig private boolean not;
 
-    @Override public void initialize() { }
+    @Override public void open() {
+        if (filter != null) {
+            filter.open();
+        }
+    }
 
     @Override
-    public boolean filterExec(Bundle row) {
+    public boolean filter(Bundle row) {
         ValueObject val = from.getValue(row);
         if (filter != null) {
             val = filter.filter(val);

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterFirstValue.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterFirstValue.java
@@ -47,7 +47,7 @@ public class BundleFilterFirstValue extends BundleFilter {
      * An array of bundle field names to search. This field is required.
      */
     @FieldConfig(codable = true, required = true)
-    private AutoField[] in;
+    private CachingField[] in;
 
     /**
      * Output destination field. This field is required.
@@ -77,7 +77,7 @@ public class BundleFilterFirstValue extends BundleFilter {
                     ValueArray arr = v.asArray();
                     if (arr.size() > 0) {
                         if (which != null) {
-                            ValueObject fieldName = ValueFactory.create(((CachingField) in[i]).name);
+                            ValueObject fieldName = ValueFactory.create(in[i].name);
                             which.setValue(bundle, fieldName);
                         }
                         out.setValue(bundle, arr);
@@ -88,7 +88,7 @@ public class BundleFilterFirstValue extends BundleFilter {
                     String str = ValueUtil.asNativeString(v);
                     if (!Strings.isEmpty(str)) {
                         if (which != null) {
-                            ValueObject fieldName = ValueFactory.create(((CachingField) in[i]).name);
+                            ValueObject fieldName = ValueFactory.create(in[i].name);
                             which.setValue(bundle, fieldName);
                         }
                         out.setValue(bundle, v);

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterFirstValue.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterFirstValue.java
@@ -17,6 +17,8 @@ import com.addthis.basis.util.Strings;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleField;
+import com.addthis.bundle.util.AutoField;
+import com.addthis.bundle.util.CachingField;
 import com.addthis.bundle.util.ValueUtil;
 import com.addthis.bundle.value.ValueArray;
 import com.addthis.bundle.value.ValueFactory;
@@ -45,57 +47,28 @@ public class BundleFilterFirstValue extends BundleFilter {
      * An array of bundle field names to search. This field is required.
      */
     @FieldConfig(codable = true, required = true)
-    private String[] in;
+    private AutoField[] in;
 
     /**
      * Output destination field. This field is required.
      */
     @FieldConfig(codable = true, required = true)
-    private String out;
+    private AutoField out;
 
     /**
      * Target field that will be populated by the name of the selected field. This field is
      * optional.
      */
     @FieldConfig(codable = true)
-    private String which;
-
-    private String[] fields;
-
-    public void setIn(String[] in) {
-        this.in = in;
-    }
-
-    public void setOut(String out) {
-        this.out = out;
-    }
-
-    public void setWhich(String which) {
-        this.which = which;
-    }
-
-    public String[] getFields() {
-        return fields;
-    }
+    private AutoField which;
 
     @Override
-    public void initialize() {
-        if (which == null) {
-            fields = new String[in.length + 1];
-        } else {
-            fields = new String[in.length + 2];
-            fields[in.length + 1] = which;
-        }
-        System.arraycopy(in, 0, fields, 0, in.length);
-        fields[in.length] = out;
-    }
+    public void open() {}
 
     @Override
-    public boolean filterExec(Bundle bundle) {
-        BundleField[] bound = getBindings(bundle, fields);
-        int end = (which == null) ? (bound.length - 1) : (bound.length - 2);
-        for (int i = 0; i < end; i++) {
-            ValueObject v = bundle.getValue(bound[i]);
+    public boolean filter(Bundle bundle) {
+        for (int i = 0; i < in.length; i++) {
+            ValueObject v = in[i].getValue(bundle);
             if (v == null) {
                 continue;
             }
@@ -104,10 +77,10 @@ public class BundleFilterFirstValue extends BundleFilter {
                     ValueArray arr = v.asArray();
                     if (arr.size() > 0) {
                         if (which != null) {
-                            ValueObject fieldName = ValueFactory.create(bound[i].getName());
-                            bundle.setValue(bound[end + 1], fieldName);
+                            ValueObject fieldName = ValueFactory.create(((CachingField) in[i]).name);
+                            which.setValue(bundle, fieldName);
                         }
-                        bundle.setValue(bound[end], arr);
+                        out.setValue(bundle, arr);
                         return true;
                     }
                     break;
@@ -115,10 +88,10 @@ public class BundleFilterFirstValue extends BundleFilter {
                     String str = ValueUtil.asNativeString(v);
                     if (!Strings.isEmpty(str)) {
                         if (which != null) {
-                            ValueObject fieldName = ValueFactory.create(bound[i].getName());
-                            bundle.setValue(bound[end + 1], fieldName);
+                            ValueObject fieldName = ValueFactory.create(((CachingField) in[i]).name);
+                            which.setValue(bundle, fieldName);
                         }
-                        bundle.setValue(bound[end], v);
+                        out.setValue(bundle, v);
                         return true;
                     }
                     break;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterLimit.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterLimit.java
@@ -40,11 +40,11 @@ public class BundleFilterLimit extends BundleFilter {
     private int limit;
 
     @Override
-    public void initialize() {
+    public void open() {
     }
 
     @Override
-    public boolean filterExec(Bundle row) {
+    public boolean filter(Bundle row) {
         return limit-- > 0;
     }
 

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterMap.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterMap.java
@@ -60,9 +60,9 @@ public class BundleFilterMap extends BundleFilter {
     private Boolean nullFail;
 
     @Override
-    public void initialize() {
+    public void open() {
         for (BundleFilterField f : fields) {
-            f.initOnceOnly();
+            f.open();
             if (nullFail != null) {
                 f.setNullFail(nullFail);
             }
@@ -70,9 +70,9 @@ public class BundleFilterMap extends BundleFilter {
     }
 
     @Override
-    public boolean filterExec(Bundle bundle) {
+    public boolean filter(Bundle bundle) {
         for (int i = 0; i < fields.length; i++) {
-            if (!fields[i].filterExec(bundle) && exitFail) {
+            if (!fields[i].filter(bundle) && exitFail) {
                 return false;
             }
         }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterMapExtract.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterMapExtract.java
@@ -16,6 +16,7 @@ package com.addthis.hydra.data.filter.bundle;
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleField;
 import com.addthis.bundle.core.BundleFormat;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.value.ValueMap;
 import com.addthis.bundle.value.ValueObject;
 import com.addthis.bundle.value.ValueTranslationException;
@@ -63,7 +64,7 @@ public class BundleFilterMapExtract extends BundleFilter {
      * The name of the field that contains the ValueMap object. This field is required.
      */
     @FieldConfig(codable = true, required = true)
-    private String field;
+    private AutoField field;
 
     /**
      * The mapping from the ValueMap to the bundle format. This field is required.
@@ -71,17 +72,12 @@ public class BundleFilterMapExtract extends BundleFilter {
     @FieldConfig(codable = true, required = true)
     private XMap[] map;
 
-    private String[] fields;
+    @Override
+    public void open() { }
 
     @Override
-    public void initialize() {
-        fields = new String[]{field};
-    }
-
-    @Override
-    public boolean filterExec(Bundle bundle) {
-        BundleField[] bound = getBindings(bundle, fields);
-        ValueObject value = bundle.getValue(bound[0]);
+    public boolean filter(Bundle bundle) {
+        ValueObject value = field.getValue(bundle);
         if (value == null) {
             return true;
         }
@@ -180,7 +176,7 @@ public class BundleFilterMapExtract extends BundleFilter {
         }
     }
 
-    BundleFilterMapExtract setField(String field) {
+    BundleFilterMapExtract setField(AutoField field) {
         this.field = field;
         return this;
     }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterNot.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterNot.java
@@ -39,10 +39,10 @@ public class BundleFilterNot extends BundleFilter {
     }
 
     @Override
-    public void initialize() { }
+    public void open() { }
 
     @Override
-    public boolean filterExec(Bundle bundle) {
+    public boolean filter(Bundle bundle) {
         return field.getValue(bundle) == null;
     }
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterNum.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterNum.java
@@ -20,6 +20,9 @@ import com.addthis.bundle.core.list.ListBundleFormat;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.hydra.data.filter.util.BundleCalculator;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 
 /**
  * This {@link BundleFilter BundleFilter} <span class="hydra-summary">performs postfix calculator operations</span>.
@@ -319,28 +322,25 @@ public class BundleFilterNum extends BundleFilter {
     /**
      * Sequence of commands to execute (comma-delimited)
      */
-    @FieldConfig(codable = true, required = true)
-    private String define;
+    final private String define;
 
     /**
      * Subset of fields from the bundle filter that are used in calculation.
      */
-    @FieldConfig(codable = true)
-    private String[] columns;
+    final private String[] columns;
 
-    private BundleCalculator calculator;
+    final private BundleCalculator calculator;
 
-
-    public BundleFilterNum setDefine(String define) {
+    @JsonCreator
+    public BundleFilterNum(@JsonProperty(value = "define", required = true) String define,
+                           @JsonProperty("columns") String[] columns) {
         this.define = define;
-        return this;
+        this.columns = columns;
+        this.calculator = new BundleCalculator(define);
     }
 
     @Override
-    public void initialize() {
-        calculator = new BundleCalculator(define);
-
-    }
+    public void open() {}
 
     protected Bundle makeAltBundle(Bundle bundle) {
         ListBundleFormat format = new ListBundleFormat();
@@ -359,7 +359,7 @@ public class BundleFilterNum extends BundleFilter {
     }
 
     @Override
-    public boolean filterExec(Bundle bundle) {
+    public boolean filter(Bundle bundle) {
         if (columns == null) {
             return calculator.calculate(bundle) != null;
         } else {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterRecent1.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterRecent1.java
@@ -21,6 +21,7 @@ import com.addthis.basis.collect.HotMap;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleField;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.util.ValueUtil;
 import com.addthis.bundle.value.ValueLong;
 import com.addthis.bundle.value.ValueObject;
@@ -40,9 +41,9 @@ import com.addthis.codec.annotations.FieldConfig;
 public final class BundleFilterRecent1 extends BundleFilter {
 
     @FieldConfig(codable = true, required = true)
-    private String          time;
+    private AutoField       time;
     @FieldConfig(codable = true, required = true)
-    private String          field;
+    private AutoField       field;
     @FieldConfig(codable = true)
     private int             track; // number of unique entries to track
     @FieldConfig(codable = true)
@@ -60,18 +61,14 @@ public final class BundleFilterRecent1 extends BundleFilter {
 
     @SuppressWarnings("unchecked")
     private HotMap<String, Mark> cache = new HotMap<>(new HashMap());
-    private String[] fields;
 
     @Override
-    public void initialize() {
-        fields = new String[]{time, field};
-    }
+    public void open() { }
 
     @Override
-    public boolean filterExec(Bundle bundle) {
-        BundleField[] bound = getBindings(bundle, fields);
-        ValueLong time = bundle.getValue(bound[0]).asLong();
-        return time != null ? accept(time.getLong(), bundle.getValue(bound[1])) : false;
+    public boolean filter(Bundle bundle) {
+        ValueLong timeValue = time.getValue(bundle).asLong();
+        return timeValue != null ? accept(timeValue.getLong(), field.getValue(bundle)) : false;
     }
 
     /**

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterRecent2.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterRecent2.java
@@ -21,6 +21,7 @@ import com.addthis.basis.collect.HotMap;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleField;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.util.ValueUtil;
 import com.addthis.bundle.value.ValueLong;
 import com.addthis.bundle.value.ValueObject;
@@ -43,9 +44,9 @@ import com.addthis.codec.annotations.FieldConfig;
 public final class BundleFilterRecent2 extends BundleFilter {
 
     @FieldConfig(codable = true, required = true)
-    private String          time;
+    private AutoField       time;
     @FieldConfig(codable = true, required = true)
-    private String          field;
+    private AutoField       field;
     @FieldConfig(codable = true, required = true)
     private int             keys; // number of unique entries to track
     @FieldConfig(codable = true, required = true)
@@ -63,18 +64,14 @@ public final class BundleFilterRecent2 extends BundleFilter {
 
     @SuppressWarnings("unchecked")
     private HotMap<String, Mark> cache = new HotMap<>(new HashMap());
-    private String[] fields;
 
     @Override
-    public void initialize() {
-        fields = new String[]{time, field};
-    }
+    public void open() { }
 
     @Override
-    public boolean filterExec(Bundle bundle) {
-        BundleField[] bound = getBindings(bundle, fields);
-        ValueLong time = bundle.getValue(bound[0]).asLong();
-        return time != null ? accept(time.getLong(), bundle.getValue(bound[1])) : false;
+    public boolean filter(Bundle bundle) {
+        ValueLong timeValue = time.getValue(bundle).asLong();
+        return timeValue != null ? accept(timeValue.getLong(), field.getValue(bundle)) : false;
     }
 
     /**

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterSleep.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterSleep.java
@@ -38,11 +38,11 @@ public class BundleFilterSleep extends BundleFilter {
     private int duration;
 
     @Override
-    public void initialize() {
+    public void open() {
     }
 
     @Override
-    public boolean filterExec(Bundle row) {
+    public boolean filter(Bundle row) {
         try {
             if (duration > 0) {
                 Thread.sleep(duration);

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTemplate.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTemplate.java
@@ -20,29 +20,34 @@ import com.addthis.bundle.core.BundleField;
 import com.addthis.bundle.value.ValueFactory;
 import com.addthis.codec.annotations.FieldConfig;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+/**
+ * @user-reference
+ */
 public class BundleFilterTemplate extends BundleFilter {
 
     private static final Logger log = LoggerFactory.getLogger(BundleFilterTemplate.class);
 
     public static BundleFilterTemplate create(String[] tokens, String set) {
-        BundleFilterTemplate bft = new BundleFilterTemplate();
-        bft.tokens = tokens;
-        bft.set = set;
-        return bft;
+        return new BundleFilterTemplate(tokens, set);
     }
 
-    @FieldConfig(codable = true, required = true)
     private String[] tokens;
-    @FieldConfig(codable = true, required = true)
     private String set;
 
     private String[] fieldSet;
     private Token[]  tokenSet;
 
-    @Override
-    public void initialize() {
+    @JsonCreator
+    public BundleFilterTemplate(@JsonProperty("tokens") String[] tokens,
+                                @JsonProperty("set") String set) {
+        this.tokens = tokens;
+        this.set = set;
         ArrayList<Token> newtokens = new ArrayList<>();
         ArrayList<String> newfields = new ArrayList<>();
         int pos = 0;
@@ -60,7 +65,10 @@ public class BundleFilterTemplate extends BundleFilter {
     }
 
     @Override
-    public boolean filterExec(Bundle bundle) {
+    public void open() { }
+
+    @Override
+    public boolean filter(Bundle bundle) {
         try {
             BundleField[] bound = getBindings(bundle, fieldSet);
             StringBuilder sb = new StringBuilder();

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTest.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTest.java
@@ -60,14 +60,14 @@ public class BundleFilterTest extends BundleFilter {
     private int loop = 1;
 
     @Override
-    public void initialize() {
-        test.initialize();
-        onTrue.initialize();
-        onFalse.initialize();
+    public void open() {
+        test.open();
+        onTrue.open();
+        onFalse.open();
     }
 
     @Override
-    public boolean filterExec(Bundle row) {
+    public boolean filter(Bundle row) {
         boolean ret = false;
         do {
             if (test.filter(row)) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTime.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTime.java
@@ -76,25 +76,14 @@ public class BundleFilterTime extends BundleFilter {
     }
 
     @Override
-    public void initialize() {
-        if (src != null && dst != null) {
-            fields = new String[]{src.getField(), dst.getField()};
-        } else if (dst != null) {
-            fields = new String[]{"", dst.getField()};
-        } else if (src != null) {
-            fields = new String[]{src.getField()};
-        }
-    }
-
-    private String[] fields;
+    public void open() { }
 
     @Override
-    public boolean filterExec(Bundle row) {
+    public boolean filter(Bundle row) {
         if (dst != null) {
-            BundleField[] bound = getBindings(row, fields);
             long unixTime;
             if (src != null) {
-                ValueObject in = row.getValue(bound[0]);
+                ValueObject in = src.getField().getValue(row);
                 if (in == null) {
                     return false;
                 }
@@ -107,7 +96,7 @@ public class BundleFilterTime extends BundleFilter {
             } else {
                 unixTime = JitterClock.globalTime();
             }
-            row.setValue(bound[1], dst.toValue(unixTime));
+            dst.getField().setValue(row, dst.toValue(unixTime));
         }
         return true;
     }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTimeRange.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTimeRange.java
@@ -15,8 +15,12 @@ package com.addthis.hydra.data.filter.bundle;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleField;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.value.ValueLong;
 import com.addthis.codec.annotations.FieldConfig;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
@@ -48,60 +52,59 @@ public class BundleFilterTimeRange extends BundleFilter {
     private static final DateTimeFormatter ymdhm = DateTimeFormat.forPattern("yyMMddHHmm");
 
     /**
-     * The date/time input as expressed in UNIX milliseconds.
+     * The field containing date/time input as expressed in UNIX milliseconds. This field is required.
      */
-    @FieldConfig(codable = true, required = true)
-    private String time;
+    final private AutoField time;
 
     /**
      * If non-null then filter out all date/time values that occur later than this value.
      */
-    @FieldConfig(codable = true)
-    private String before;
+    final private String before;
 
     /**
      * If non-null then filter out all date/time values that occur earlier than this value.
      */
-    @FieldConfig(codable = true)
-    private String after;
+    final private String after;
 
     /**
      * The value to return when a date/time value is within the filter(s). Default is true.
      */
-    @FieldConfig(codable = true)
-    private boolean defaultExit = true;
+    final private boolean defaultExit;
 
     /**
      * If non-null then parse the 'before' and 'after' fields using this
      * <a href="http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat
      * .html">DateTimeFormat</a>.
      */
-    @FieldConfig(codable = true)
-    private String timeFormat;
+    final private String timeFormat;
 
-    private long              tbefore;
-    private long              tafter;
-    private DateTimeFormatter format;
-    private String[]            fields;
+    final private long              tbefore;
+    final private long              tafter;
+    final private DateTimeFormatter format;
 
-    @Override
-    public void initialize() {
-        fields = new String[]{time};
-        if (timeFormat != null) {
-            format = DateTimeFormat.forPattern(timeFormat);
-        }
-        if (before != null) {
-            tbefore = convertDate(before);
-        }
-        if (after != null) {
-            tafter = convertDate(after);
-        }
+    @JsonCreator
+    public BundleFilterTimeRange(@JsonProperty(value = "time", required = true) AutoField time,
+                                 @JsonProperty("before") String before,
+                                 @JsonProperty("after") String after,
+                                 @JsonProperty("defaultExit") boolean defaultExit,
+                                 @JsonProperty("timeFormat") String timeFormat) {
+        this.time = time;
+        this.before = before;
+        this.after = after;
+        this.defaultExit = defaultExit;
+        this.timeFormat = timeFormat;
+
+        format = (timeFormat != null) ? DateTimeFormat.forPattern(timeFormat) : null;
+        tbefore = (before != null) ? convertDate(before) : null;
+        tafter = (after != null) ? convertDate(after) : null;
     }
 
     @Override
-    public boolean filterExec(Bundle bundle) {
-        BundleField[] bound = getBindings(bundle, fields);
-        ValueLong timeValue = bundle.getValue(bound[0]).asLong();
+    public void open() { }
+
+    @Override
+    public boolean filter(Bundle bundle) {
+        ValueLong timeValue = time.getValue(bundle).asLong();
         if (timeValue == null) {
             return defaultExit;
         }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTry.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTry.java
@@ -24,6 +24,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * is usually to set catchDo to a no-op filter that always returns true. Reasonable
  * alternatives include logging (via filter debug or setting a specific field),
  * conditionally rethrowing with a filter that may fail, and imagination.
+ *
+ * @user-reference
+ * @hydra-name try
  */
 public class BundleFilterTry extends BundleFilter {
 
@@ -36,15 +39,15 @@ public class BundleFilterTry extends BundleFilter {
     BundleFilter catchDo;
 
     @Override
-    public void initialize() {
-        tryDo.initOnceOnly();
+    public void open() {
+        tryDo.open();
         if (catchDo != null) {
-            catchDo.initOnceOnly();
+            catchDo.open();
         }
     }
 
     @Override
-    public boolean filterExec(Bundle row) {
+    public boolean filter(Bundle row) {
         boolean tryResult = tryDo.filter(row);
         return tryResult || (catchDo == null) || catchDo.filter(row);
     }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/unary/BundleFilterUnary.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/unary/BundleFilterUnary.java
@@ -35,14 +35,14 @@ public class BundleFilterUnary extends BundleFilter {
         this.filter = filter;
     }
 
-    @Override public void initialize() {
+    @Override public void open() {
         if (filter != null) {
-            filter.initOnceOnly();
+            filter.open();
         }
     }
 
-    @Override public boolean filterExec(Bundle row) {
-        boolean filterResult = (filter == null) || filter.filterExec(row);
+    @Override public boolean filter(Bundle row) {
+        boolean filterResult = (filter == null) || filter.filter(row);
         return operation.compute(filterResult);
     }
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterChain.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterChain.java
@@ -39,16 +39,16 @@ public class CloseableBundleFilterChain extends CloseableBundleFilter {
     private boolean debug;
 
     @Override
-    public void initialize() {
+    public void open() {
         for (CloseableBundleFilter f : filter) {
-            f.initOnceOnly();
+            f.open();
         }
     }
 
     @Override
-    public boolean filterExec(Bundle row) {
+    public boolean filter(Bundle row) {
         for (BundleFilter f : filter) {
-            if (!f.filterExec(row) && failStop) {
+            if (!f.filter(row) && failStop) {
                 if (debug) {
                     log.warn("fail @ " + CodecJSON.tryEncodeString(f, "UNKNOWN"));
                 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterDelete.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterDelete.java
@@ -35,6 +35,13 @@ public class CloseableBundleFilterDelete extends CloseableBundleFilter {
     private Logger log = LoggerFactory.getLogger(CloseableBundleFilterDelete.class);
 
     @Override
+    public void open() {
+        if (pre) {
+            delete(fileName);
+        }
+    }
+
+    @Override
     public void close() {
         if (!pre) {
             delete(fileName);
@@ -57,14 +64,7 @@ public class CloseableBundleFilterDelete extends CloseableBundleFilter {
     }
 
     @Override
-    public void initialize() {
-        if (pre) {
-            delete(fileName);
-        }
-    }
-
-    @Override
-    public boolean filterExec(Bundle row) {
+    public boolean filter(Bundle row) {
         return true;
     }
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterSet.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterSet.java
@@ -15,6 +15,7 @@ package com.addthis.hydra.data.filter.closeablebundle;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleField;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.value.ValueFactory;
 import com.addthis.codec.annotations.FieldConfig;
 
@@ -24,19 +25,16 @@ public class CloseableBundleFilterSet extends CloseableBundleFilter {
     @FieldConfig(codable = true, required = true)
     private String value;
     @FieldConfig(codable = true, required = true)
-    private String to;
+    private AutoField to;
     @FieldConfig(codable = true)
     private CloseableBundleFilter filter;
     @FieldConfig(codable = true)
     private boolean not;
 
-    private String[] fields;
-
     @Override
-    public void initialize() {
-        fields = new String[]{to};
+    public void open() {
         if (filter != null) {
-            filter.initOnceOnly();
+            filter.open();
         }
     }
 
@@ -48,16 +46,15 @@ public class CloseableBundleFilterSet extends CloseableBundleFilter {
     }
 
     @Override
-    public boolean filterExec(Bundle bundle) {
+    public boolean filter(Bundle bundle) {
         boolean success = true;
-        BundleField[] bound = getBindings(bundle, fields);
 
         if (filter != null) {
             success = filter.filter(bundle);
         }
 
         if (success) {
-            bundle.setValue(bound[0], ValueFactory.create(value));
+            to.setValue(bundle, ValueFactory.create(value));
             return !not;
         } else {
             return not;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBandPass.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBandPass.java
@@ -74,6 +74,9 @@ public class ValueFilterBandPass extends StringFilter {
     };
 
     @Override
+    public void open() {}
+
+    @Override
     public String filter(String value) {
         if (value == null) {
             return value;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBase64.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBase64.java
@@ -51,6 +51,9 @@ public class ValueFilterBase64 extends StringFilter {
     private boolean decode;
 
     @Override
+    public void open() {}
+
+    @Override
     public String filter(String value) {
         if (!Strings.isEmpty(value)) {
             if (encode) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBaseConv.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBaseConv.java
@@ -41,6 +41,9 @@ public class ValueFilterBaseConv extends ValueFilter {
     }
 
     @Override
+    public void open() {}
+
+    @Override
     public ValueObject filterValue(ValueObject value) {
         if (decode) {
             return decode(value);

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBitsToArray.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBitsToArray.java
@@ -73,6 +73,9 @@ public class ValueFilterBitsToArray extends ValueFilter {
     }
 
     @Override
+    public void open() {}
+
+    @Override
     public ValueObject filterValue(ValueObject value) {
         long bits = getBitValue(value);
         ValueArray arr = ValueFactory.createArray(64);

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCase.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCase.java
@@ -46,6 +46,9 @@ public class ValueFilterCase extends StringFilter {
     private boolean upper;
 
     @Override
+    public void open() {}
+
+    @Override
     public String filter(String value) {
         if (value != null) {
             if (lower) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCat.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCat.java
@@ -43,6 +43,9 @@ public class ValueFilterCat extends ValueFilter {
     private String post;
 
     @Override
+    public void open() {}
+
+    @Override
     public ValueObject filterValue(ValueObject value) {
         if (value != null) {
             if (pre != null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterChain.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterChain.java
@@ -50,6 +50,13 @@ public class ValueFilterChain extends ValueFilter {
     private boolean nullStop = true;
 
     @Override
+    public void open() {
+        for (ValueFilter f : filter) {
+            f.open();
+        }
+    }
+
+    @Override
     public ValueObject filterValue(ValueObject value) {
         for (ValueFilter f : filter) {
             if (value != null || !nullStop || f.getNullAccept()) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterContains.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterContains.java
@@ -95,7 +95,7 @@ public class ValueFilterContains extends ValueFilter {
     }
 
     @Override
-    public void setup() {
+    public void open() {
         if (value != null) {
             dictionary = new AhoCorasick();
             for (String pattern : value) {
@@ -107,8 +107,6 @@ public class ValueFilterContains extends ValueFilter {
 
     @Override
     public ValueObject filterValue(ValueObject input) {
-
-        requireSetup();
 
         if (input == null) {
             return null;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterContains.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterContains.java
@@ -24,6 +24,10 @@ import com.addthis.bundle.value.ValueMap;
 import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import org.arabidopsis.ahocorasick.AhoCorasick;
 import org.arabidopsis.ahocorasick.SearchResult;
 
@@ -56,48 +60,40 @@ public class ValueFilterContains extends ValueFilter {
     /**
      * The set of values to match against.
      */
-    @FieldConfig(codable = true)
-    private String[] value;
+    final private String[] value;
 
     /**
      * The set of keys to match against. Only applicable for map inputs.
      */
-    @FieldConfig(codable = true)
-    private String[] key;
+    final private String[] key;
 
     /**
      * If true then return values that do not match. Default is false.
      */
-    @FieldConfig(codable = true)
-    private boolean not;
+    final private boolean not;
 
     /**
      * If true then matched value is returned v/s the input
      */
-    @FieldConfig(codable = true)
-    private boolean returnMatch;
+    final private boolean returnMatch;
 
-    private AhoCorasick dictionary;
+    final private AhoCorasick dictionary;
 
-    public ValueFilterContains setValues(String[] value) {
+    @JsonCreator
+    public ValueFilterContains(@JsonProperty("value") String[] value,
+                               @JsonProperty("key") String[] key,
+                               @JsonProperty("not") boolean not,
+                               @JsonProperty("returnMatch") boolean returnMatch) {
         this.value = value;
-        return this;
-    }
-
-    public ValueFilterContains setNot(boolean not) {
+        this.key = key;
         this.not = not;
-        return this;
-    }
-
-    public ValueFilterContains setReturnMatch(boolean returnMatch) {
         this.returnMatch = returnMatch;
-        return this;
+        this.dictionary = (value != null) ? new AhoCorasick() : null;
     }
 
     @Override
     public void open() {
-        if (value != null) {
-            dictionary = new AhoCorasick();
+        if (dictionary != null) {
             for (String pattern : value) {
                 dictionary.add(pattern);
             }
@@ -112,7 +108,7 @@ public class ValueFilterContains extends ValueFilter {
             return null;
         }
 
-        String match = null;
+        String match;
         ValueObject.TYPE type = input.getObjectType();
         if (type == ValueObject.TYPE.MAP) {
             ValueMap inputAsMap = input.asMap();

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCounter.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCounter.java
@@ -21,6 +21,9 @@ import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * This {@link ValueFilter ValueFilter} <span class="hydra-summary">counts the number of values it has observed</span>.
  * <p/>
@@ -55,33 +58,39 @@ public class ValueFilterCounter extends ValueFilter {
     /**
      * The {@link DecimalFormat DecimalFormat} input string.
      */
-    @FieldConfig(codable = true)
-    private String format;
+    private final String format;
 
-    /**
+    /**-
      * The starting value of the counter. Default is 0.
      */
-    @FieldConfig(codable = true)
-    private int start;
+    private final int start;
 
     /**
      * The counter increment for each input item. Default is 1.
      */
-    @FieldConfig(codable = true)
-    private int increment = 1;
+    private final int increment;
 
     /**
      * If non-zero, then emit an output for each <i>N</i><sup>th</sup> item. Default is 0.
      */
-    @FieldConfig(codable = true)
-    private int sample;
+    private final int sample;
 
-    private AtomicInteger counter = new AtomicInteger();
+    private final AtomicInteger counter = new AtomicInteger();
 
-    @Override
-    public void setup() {
+    @JsonCreator
+    public ValueFilterCounter(@JsonProperty("format") String format,
+                              @JsonProperty("start") int start,
+                              @JsonProperty("increment") int increment,
+                              @JsonProperty("sample") int sample) {
+        this.format = format;
+        this.start = start;
+        this.increment = increment;
+        this.sample = sample;
         counter.set(start);
     }
+
+    @Override
+    public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCreateMap.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCreateMap.java
@@ -64,6 +64,8 @@ public class ValueFilterCreateMap extends ValueFilter {
     @FieldConfig(codable = true)
     private boolean includeNullValues = false;
 
+    @Override
+    public void open() {}
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterDateRangeLength.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterDateRangeLength.java
@@ -84,6 +84,9 @@ public class ValueFilterDateRangeLength extends StringFilter {
     }
 
     @Override
+    public void open() {}
+
+    @Override
     public String filter(String value) {
         if (value != null) {
             try {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterDefault.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterDefault.java
@@ -59,6 +59,9 @@ public class ValueFilterDefault extends StringFilter {
     }
 
     @Override
+    public void open() {}
+
+    @Override
     public String filter(String v) {
         if (Strings.isEmpty(v)) {
             return time ? Long.toString(JitterClock.globalTime()) : value;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterEmpty.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterEmpty.java
@@ -45,6 +45,9 @@ public class ValueFilterEmpty extends ValueFilter {
     private boolean not;
 
     @Override
+    public void open() {}
+
+    @Override
     public ValueObject filterValue(ValueObject value) {
         if (value == null) {
             return null;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterEvalJava.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterEvalJava.java
@@ -163,9 +163,12 @@ public class ValueFilterEvalJava extends ValueFilter {
         requiredImports.add("import java.util.Map;");
     }
 
+    @Override public void open() {
+        constructedFilter = createConstructedFilter();
+    }
+
     @Override
     public ValueObject filterValue(ValueObject value) {
-        requireSetup();
         if (constructedFilter != null) {
             return constructedFilter.filter(value);
         } else {
@@ -228,6 +231,7 @@ public class ValueFilterEvalJava extends ValueFilter {
                 log.warn("\n" + classDeclString);
                 throw new IllegalStateException(msg);
             }
+            filter.open();
             return filter;
         } finally {
             compiler.cleanupFiles(className);
@@ -321,11 +325,6 @@ public class ValueFilterEvalJava extends ValueFilter {
         classDecl.append(getOnce());
         classDecl.append(");\n");
         classDecl.append("}\n\n");
-    }
-
-
-    @Override public void setup() {
-        constructedFilter = createConstructedFilter();
     }
 
     public void setInputType(InputType type) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterGlob.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterGlob.java
@@ -41,6 +41,8 @@ public class ValueFilterGlob extends StringFilter {
         compiled = FileSystems.getDefault().getPathMatcher("glob:" + pattern);
     }
 
+    @Override public void open() { }
+
     @Override
     @Nullable
     public String filter(String sv) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterGrepTags.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterGrepTags.java
@@ -52,6 +52,8 @@ public class ValueFilterGrepTags extends ValueFilter {
 
     private int parserErrors = 0;
 
+    @Override public void open() { }
+
     @Override
     @Nullable
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterHash.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterHash.java
@@ -62,6 +62,8 @@ public class ValueFilterHash extends ValueFilter {
     @FieldConfig(codable = true)
     private boolean abs;
 
+    @Override public void open() { }
+
     @Override
     public ValueObject filterValue(ValueObject value) {
         if (value == null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterHttpGet.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterHttpGet.java
@@ -91,35 +91,34 @@ public class ValueFilterHttpGet extends StringFilter {
         }
     }
 
-    private void checkInit() {
-        if (init.compareAndSet(false, true)) {
-            if (persist) {
-                persistTo = Files.initDirectory(persistDir);
-                LinkedList<CacheObject> list = new LinkedList<>();
-                for (File file : persistTo.listFiles()) {
-                    if (file.isFile()) {
-                        try {
-                            CacheObject cached = codec.decode(CacheObject.class, Files.read(file));
-                            cached.hash = file.getName();
-                            list.add(cached);
-                            if (log.isDebugEnabled()) {
-                                log.debug("restored " + cached.hash + " as " + cached.key);
-                            }
-                        } catch (Exception e) {
-                            e.printStackTrace();
+    @Override
+    public void open() {
+        if (persist) {
+            persistTo = Files.initDirectory(persistDir);
+            LinkedList<CacheObject> list = new LinkedList<>();
+            for (File file : persistTo.listFiles()) {
+                if (file.isFile()) {
+                    try {
+                        CacheObject cached = codec.decode(CacheObject.class, Files.read(file));
+                        cached.hash = file.getName();
+                        list.add(cached);
+                        if (log.isDebugEnabled()) {
+                            log.debug("restored " + cached.hash + " as " + cached.key);
                         }
+                    } catch (Exception e) {
+                        e.printStackTrace();
                     }
                 }
-                // sort so that hot map has the most recent inserted last
-                CacheObject[] sort = new CacheObject[list.size()];
-                list.toArray(sort);
-                Arrays.sort(sort);
-                for (CacheObject cached : sort) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("insert into hot " + cached.hash + " as " + cached.key);
-                    }
-                    cache.put(cached.key, cached);
+            }
+            // sort so that hot map has the most recent inserted last
+            CacheObject[] sort = new CacheObject[list.size()];
+            list.toArray(sort);
+            Arrays.sort(sort);
+            for (CacheObject cached : sort) {
+                if (log.isDebugEnabled()) {
+                    log.debug("insert into hot " + cached.hash + " as " + cached.key);
                 }
+                cache.put(cached.key, cached);
             }
         }
     }
@@ -158,7 +157,6 @@ public class ValueFilterHttpGet extends StringFilter {
         if (sv == null) {
             return sv;
         }
-        checkInit();
         CacheObject cached = cacheGet(sv);
         if (cached == null || (cacheAge > 0 && System.currentTimeMillis() - cached.time > cacheAge)) {
             if (log.isDebugEnabled() && cached != null && cacheAge > 0 && System.currentTimeMillis() - cached.time > cacheAge) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterIndex.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterIndex.java
@@ -59,6 +59,8 @@ public class ValueFilterIndex extends ValueFilter {
         return this;
     }
 
+    @Override public void open() { }
+
     @Override
     public ValueObject filter(ValueObject value) {
         ValueObject nullReturn = toNull ? null : value;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterInequality.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterInequality.java
@@ -65,6 +65,8 @@ public class ValueFilterInequality extends ValueFilter {
         this.rh = rh;
     }
 
+    @Override public void open() { }
+
     // pass through if true, else null
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterIntBase.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterIntBase.java
@@ -60,6 +60,8 @@ public class ValueFilterIntBase extends ValueFilter {
     @FieldConfig(codable = true)
     private boolean inDouble = false;
 
+    @Override public void open() { }
+
     @Override
     public ValueObject filterValue(ValueObject value) {
         if (value == null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJSON.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJSON.java
@@ -58,6 +58,8 @@ public class ValueFilterJSON extends ValueFilter implements SuperCodable {
     private HotMap<String, Object> cache = new HotMap<>(new ConcurrentHashMap());
     private ArrayList<QueryToken> tokens;
 
+    @Override public void open() { }
+
     @Override
     public ValueObject filterValue(ValueObject value) {
         if ((value == null) || ((value.getObjectType() == ValueObject.TYPE.STRING) &&

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJavascript.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJavascript.java
@@ -24,18 +24,13 @@ import com.addthis.codec.codables.SuperCodable;
  * Value filter based on the JSR 223 scripting interface, and the default
  * implementation based on Rhino, shipped with the 1.6 JDK.
  */
-public class ValueFilterJavascript extends StringFilter implements SuperCodable {
+public class ValueFilterJavascript extends StringFilter {
 
     @FieldConfig(codable = true)
     private String source;
     private Filter filter;
 
-    @Override
-    public void preEncode() {
-    }
-
-    @Override
-    public void postDecode() {
+    @Override public void open() {
         if (source == null) {
             throw new IllegalArgumentException("no source specified!");
         }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJoin.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJoin.java
@@ -100,6 +100,15 @@ public class ValueFilterJoin extends ValueFilter {
         return this;
     }
 
+    @Override public void open() {
+        if (filter != null) {
+            filter.open();
+        }
+        if (keyFilter != null) {
+            keyFilter.open();
+        }
+    }
+
     @Override
     public ValueObject filterValue(ValueObject value) {
         return filter != null ? filter.filter(value) : value;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterLength.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterLength.java
@@ -34,6 +34,8 @@ import com.addthis.bundle.value.ValueObject;
  */
 public class ValueFilterLength extends ValueFilter {
 
+    @Override public void open() { }
+
     @Override
     public ValueObject filterValue(ValueObject value) {
         if (value != null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterListApply.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterListApply.java
@@ -37,6 +37,10 @@ public class ValueFilterListApply extends ValueFilter {
     @FieldConfig(codable = true, required = true)
     private ValueFilter elementFilter;
 
+    @Override public void open() {
+        elementFilter.open();
+    }
+
     @Override
     // This is a essentially a copy of the default ValueFilter.filter (which applies filterValue to list elements).
     // Reason: some filters override filter rather than filterValue, which prevents them from being applied

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMD5.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMD5.java
@@ -30,6 +30,8 @@ import com.addthis.hydra.common.hash.MD5HashFunction;
  */
 public class ValueFilterMD5 extends ValueFilter {
 
+    @Override public void open() { }
+
     @Override
     public ValueObject filterValue(ValueObject value) {
         if (value != null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMap.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMap.java
@@ -109,7 +109,7 @@ public class ValueFilterMap extends StringFilter {
     }
 
     @Override
-    public void setup() {
+    public void open() {
         if (map == null && mapURL != null) {
             map = new JSONFetcher(httpTimeout, httpTrace).loadMap(mapURL);
         }
@@ -117,7 +117,6 @@ public class ValueFilterMap extends StringFilter {
 
     @Override
     public String filter(String value) {
-        requireSetup();
         if (value != null) {
             if (map == null) {
                 value = defaultValue != null ? defaultValue : toNull ? null : value;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMapSubset.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMapSubset.java
@@ -75,6 +75,8 @@ public class ValueFilterMapSubset extends ValueFilter {
     @JsonProperty private String valueSep = ",";
 
 
+    @Override public void open() { }
+
     @Override
     public ValueObject filterValue(ValueObject value) {
         if (value == null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMapValue.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMapValue.java
@@ -37,6 +37,8 @@ public class ValueFilterMapValue extends ValueFilter {
     @FieldConfig(codable = true)
     private String key;
 
+    @Override public void open() { }
+
     @Override
     public ValueObject filterValue(ValueObject value) {
         if (value == null || value.getObjectType() != ValueObject.TYPE.MAP) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMod.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMod.java
@@ -44,6 +44,8 @@ public class ValueFilterMod extends ValueFilter {
     @FieldConfig(codable = true)
     private boolean abs = true;
 
+    @Override public void open() { }
+
     @Override
     public ValueObject filterValue(ValueObject value) {
         try {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterNot.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterNot.java
@@ -19,6 +19,17 @@ import com.addthis.bundle.value.ValueObject;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+
+/**
+ * This {@link ValueFilter ValueFilter} <span class="hydra-summary">negates another value filter</span>.
+ * <p/>
+ * <p>Example:</p>
+ * <pre>
+ * </pre>
+ *
+ * @user-reference
+ * @hydra-name not
+ */
 public class ValueFilterNot extends ValueFilter {
 
     private final ValueFilter filter;
@@ -27,6 +38,10 @@ public class ValueFilterNot extends ValueFilter {
         this.filter = filter;
         this.once = filter.once;
         this.nullAccept = filter.nullAccept;
+    }
+
+    @Override public void open() {
+        filter.open();
     }
 
     @Override

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterPad.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterPad.java
@@ -48,6 +48,8 @@ public class ValueFilterPad extends StringFilter {
     @FieldConfig(codable = true)
     private String right;
 
+    @Override public void open() { }
+
     @Override
     public String filter(String v) {
         if (v == null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterPass.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterPass.java
@@ -31,6 +31,8 @@ import com.addthis.bundle.value.ValueObject;
  */
 public class ValueFilterPass extends ValueFilter {
 
+    @Override public void open() { }
+
     @Override
     public ValueObject filter(ValueObject v) {
         return v;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRandom.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRandom.java
@@ -89,6 +89,8 @@ public class ValueFilterRandom extends ValueFilter {
 
     private DecimalFormat format;
 
+    @Override public void open() { }
+
     @Override
     public ValueObject filterValue(ValueObject value) {
         if (gaussian) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRange.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRange.java
@@ -46,6 +46,8 @@ public class ValueFilterRange extends StringFilter {
         return this;
     }
 
+    @Override public void open() { }
+
     @Override
     public String filter(String sv) {
         if (sv == null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRegex.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRegex.java
@@ -61,7 +61,7 @@ public class ValueFilterRegex extends ValueFilter {
      * Regular expression to match against. This field is required.
      */
     @FieldConfig(codable = true, required = true)
-    private String pattern;
+    private Pattern pattern;
 
     /**
      * If non-null, then replace all matches with this string. Default is null.
@@ -69,9 +69,7 @@ public class ValueFilterRegex extends ValueFilter {
     @FieldConfig(codable = true)
     private String replace;
 
-    private volatile Pattern compiled;
-
-    public ValueFilterRegex setPattern(String p) {
+    public ValueFilterRegex setPattern(Pattern p) {
         pattern = p;
         return this;
     }
@@ -82,15 +80,15 @@ public class ValueFilterRegex extends ValueFilter {
     }
 
     @Override
+    public void open() {}
+
+    @Override
     public ValueObject filterValue(ValueObject value) {
-        if (compiled == null) {
-            compiled = Pattern.compile(pattern);
-        }
         String sv = ValueUtil.asNativeString(value);
         if (sv == null) {
             return null;
         }
-        Matcher matcher = compiled.matcher(sv);
+        Matcher matcher = pattern.matcher(sv);
         if (replace != null) {
             return ValueFactory.create(matcher.replaceAll(replace));
         }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRequire.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRequire.java
@@ -20,6 +20,9 @@ import java.util.regex.Pattern;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.hydra.data.util.JSONFetcher;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * This {@link ValueFilter ValueFilter} <span class="hydra-summary">filters the input based on one or more string-matching criteria</span>.
  * <p/>
@@ -52,102 +55,110 @@ public class ValueFilterRequire extends StringFilter {
     /**
      * The input must match exactly to an element in this set.
      */
-    @FieldConfig(codable = true)
     private HashSet<String> value;
 
     /**
      * A URL to retrieve the 'value' field.
      */
-    @FieldConfig(codable = true)
-    private String valueURL;
+    final private String valueURL;
 
     /**
      * The input must match to one of the regular expressions in this set.
      */
-    @FieldConfig(codable = true)
     private HashSet<String> match;
 
     /**
      * A URL to retrieve the 'match' field.
      */
-    @FieldConfig(codable = true)
-    private String matchURL;
+    final private String matchURL;
 
     /**
      * A substring of the input must match to one of the regular expressions in this set.
      */
-    @FieldConfig(codable = true)
     private HashSet<String> find;
 
     /**
      * A URL to retrieve the 'find' field.
      */
-    @FieldConfig(codable = true)
-    private String findURL;
+    final private String findURL;
 
     /**
      * A substring of the input must match exactly to an element of this set.
      */
-    @FieldConfig(codable = true)
     private String[] contains;
 
     /**
      * A URL to retrieve the 'contains' field.
      */
-    @FieldConfig(codable = true)
-    private String containsURL;
+    final private String containsURL;
 
     /**
      * If true, then interpret the payload from the URLs as CSV files. Default is false.
      */
     @FieldConfig(codable = true)
-    private boolean urlReturnsCSV;
+    final private boolean urlReturnsCSV;
 
     /**
      * If true, then convert the input to lowercase. The filter output will be in lowercase.
      * Default is false.
      */
     @FieldConfig(codable = true)
-    private boolean toLower;
+    final private boolean toLower;
 
     /**
      * A timeout value if any of the URL fields are used. Default is 60000.
      */
     @FieldConfig(codable = true)
-    private int urlTimeout = 60000;
+    final private int urlTimeout;
 
     /**
      * The number of retries if any of the URL fields are used. Default is 5.
      */
     @FieldConfig(codable = true)
-    private int urlRetries = 5;
+    final private int urlRetries;
 
     private ArrayList<Pattern> pattern;
     private ArrayList<Pattern> findPattern;
 
-    public ValueFilterRequire setValue(HashSet<String> value) {
+    @JsonCreator
+    public ValueFilterRequire(@JsonProperty("value") HashSet<String> value,
+                              @JsonProperty("valueURL") String valueURL,
+                              @JsonProperty("match") HashSet<String> match,
+                              @JsonProperty("matchURL") String matchURL,
+                              @JsonProperty("find") HashSet<String> find,
+                              @JsonProperty("findURL") String findURL,
+                              @JsonProperty("contains") String[] contains,
+                              @JsonProperty("containsURL") String containsURL,
+                              @JsonProperty("urlReturnsCSV") boolean urlReturnsCSV,
+                              @JsonProperty("toLower") boolean toLower,
+                              @JsonProperty("urlTimeout") int urlTimeout,
+                              @JsonProperty("urlRetries") int urlRetries) {
         this.value = value;
-        return this;
-    }
-
-    public ValueFilterRequire setMatch(HashSet<String> match) {
+        this.valueURL = valueURL;
         this.match = match;
-        return this;
-    }
-
-    public ValueFilterRequire setContains(String[] contains) {
-        this.contains = contains;
-        return this;
-    }
-
-    public ValueFilterRequire setFind(HashSet<String> find) {
+        this.matchURL = matchURL;
         this.find = find;
-        return this;
-    }
-
-    public ValueFilterRequire setToLower(boolean toLower) {
+        this.findURL = findURL;
+        this.contains = contains;
+        this.containsURL = containsURL;
+        this.urlReturnsCSV = urlReturnsCSV;
         this.toLower = toLower;
-        return this;
+        this.urlTimeout = urlTimeout;
+        this.urlRetries = urlRetries;
+        if (match != null) {
+            ArrayList<Pattern> np = new ArrayList<>();
+            for (String s : match) {
+                np.add(Pattern.compile(s));
+            }
+            this.pattern = np;
+        }
+        if (find != null) {
+            ArrayList<Pattern> np = new ArrayList<>();
+            for (String s : find) {
+                np.add(Pattern.compile(s));
+            }
+            this.findPattern = np;
+        }
     }
 
     public boolean passedMatch(String sv) {
@@ -195,7 +206,7 @@ public class ValueFilterRequire extends StringFilter {
     }
 
     @Override
-    public void setup() {
+    public void open() {
         if (valueURL != null) {
             if (urlReturnsCSV) {
                 value = JSONFetcher.staticLoadCSVSet(valueURL, urlTimeout, urlRetries, value);
@@ -209,12 +220,26 @@ public class ValueFilterRequire extends StringFilter {
             } else {
                 match = JSONFetcher.staticLoadSet(matchURL, urlTimeout, urlRetries, match);
             }
+            if (match != null) {
+                ArrayList<Pattern> np = new ArrayList<>();
+                for (String s : match) {
+                    np.add(Pattern.compile(s));
+                }
+                this.pattern = np;
+            }
         }
         if (findURL != null) {
             if (urlReturnsCSV) {
                 find = JSONFetcher.staticLoadCSVSet(findURL, urlTimeout, urlRetries, find);
             } else {
                 find = JSONFetcher.staticLoadSet(findURL, urlTimeout, urlRetries, find);
+            }
+            if (find != null) {
+                ArrayList<Pattern> np = new ArrayList<>();
+                for (String s : find) {
+                    np.add(Pattern.compile(s));
+                }
+                this.findPattern = np;
             }
         }
         if (containsURL != null) {
@@ -228,25 +253,10 @@ public class ValueFilterRequire extends StringFilter {
 
             contains = tmp.toArray(new String[tmp.size()]);
         }
-        if (match != null) {
-            ArrayList<Pattern> np = new ArrayList<>();
-            for (String s : match) {
-                np.add(Pattern.compile(s));
-            }
-            this.pattern = np;
-        }
-        if (find != null) {
-            ArrayList<Pattern> np = new ArrayList<>();
-            for (String s : find) {
-                np.add(Pattern.compile(s));
-            }
-            this.findPattern = np;
-        }
     }
 
     @Override
     public String filter(String sv) {
-        requireSetup();
         if (sv != null && !sv.equals("")) {
             if (toLower) {
                 sv = sv.toLowerCase();

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterReverse.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterReverse.java
@@ -31,6 +31,9 @@ import com.addthis.bundle.value.ValueObject;
 public class ValueFilterReverse extends ValueFilter {
 
     @Override
+    public void open() { }
+
+    @Override
     public ValueObject filterValue(ValueObject value) {
         if (value == null) {
             return null;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSeen.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSeen.java
@@ -80,6 +80,13 @@ public class ValueFilterSeen extends ValueFilter {
         }
     }
 
+    @Override
+    public void open() {
+        if (filter != null) {
+            filter.open();
+        }
+    }
+
     private boolean initialize() {
         if (bloom == null && url != null) {
             SeenFilterBasic<Raw> newbloom = new SeenFilterBasic<>();

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSerial.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSerial.java
@@ -68,6 +68,9 @@ public class ValueFilterSerial extends ValueFilter {
     private int base;
 
     @Override
+    public void open() { }
+
+    @Override
     public synchronized ValueObject filterValue(ValueObject value) {
         if (mod > 0) {
             seed = (seed + 1) % mod;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSet.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSet.java
@@ -17,6 +17,9 @@ import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns a constant value</span>.
  * <p/>
@@ -33,16 +36,21 @@ public class ValueFilterSet extends ValueFilter {
     /**
      * The output value.
      */
-    @FieldConfig(codable = true)
-    private String value;
+    private final String value;
 
-    private ValueObject cache;
+    private final ValueObject cache;
+
+    @JsonCreator
+    public ValueFilterSet(@JsonProperty("value") String value) {
+        this.value = value;
+        this.cache = ValueFactory.create(value);
+    }
+
+    @Override
+    public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject v) {
-        if (cache == null && value != null) {
-            cache = ValueFactory.create(value);
-        }
         return cache;
     }
 

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSlice.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSlice.java
@@ -61,6 +61,9 @@ public class ValueFilterSlice extends ValueFilter {
     }
 
     @Override
+    public void open() { }
+
+    @Override
     public ValueObject filter(ValueObject value) {
         if (value == null) {
             return value;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSort.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSort.java
@@ -31,24 +31,24 @@ import com.addthis.bundle.value.ValueObject;
  */
 public class ValueFilterSort extends ValueFilter {
 
-    private static final Comparator<ValueObject> valueObjectComparator = new Comparator<ValueObject>() {
-        @Override
-        public int compare(ValueObject o1, ValueObject o2) {
-            if (o1.getObjectType() != o2.getObjectType()) {
-                throw new RuntimeException("Sort error: different object types: " + o1.getObjectType() + "," + o2.getObjectType());
-            }
-            switch (o1.getObjectType()) {
-                case STRING:
-                    return o1.asString().asNative().compareTo(o2.asString().asNative());
-                case INT:
-                    return Long.compare(o1.asLong().getLong(), o2.asLong().getLong()); // DefaultLong.TYPE = INT, go figure
-                case FLOAT:
-                    return Double.compare(o1.asDouble().getDouble(), o2.asDouble().getDouble()); // ... and DefaultDouble.TYPE = FLOAT
-                default:
-                    throw new RuntimeException("Sort error: unsupported object type " + o1.getObjectType());
-            }
+    private static final Comparator<ValueObject> valueObjectComparator = (o1, o2) -> {
+        if (o1.getObjectType() != o2.getObjectType()) {
+            throw new RuntimeException("Sort error: different object types: " + o1.getObjectType() + "," + o2.getObjectType());
+        }
+        switch (o1.getObjectType()) {
+            case STRING:
+                return o1.asString().asNative().compareTo(o2.asString().asNative());
+            case INT:
+                return Long.compare(o1.asLong().getLong(), o2.asLong().getLong()); // DefaultLong.TYPE = INT, go figure
+            case FLOAT:
+                return Double.compare(o1.asDouble().getDouble(), o2.asDouble().getDouble()); // ... and DefaultDouble.TYPE = FLOAT
+            default:
+                throw new RuntimeException("Sort error: unsupported object type " + o1.getObjectType());
         }
     };
+
+    @Override
+    public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSplit.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSplit.java
@@ -119,6 +119,17 @@ public class ValueFilterSplit extends ValueFilter {
     }
 
     @Override
+    public void open() {
+        if (filter != null) {
+            filter.open();
+        }
+        if (keyFilter != null) {
+            keyFilter.open();
+        }
+    }
+
+
+    @Override
     public ValueObject filterValue(ValueObject value) {
         return filter != null ? filter.filter(value) : value;
     }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterStringSlice.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterStringSlice.java
@@ -81,6 +81,9 @@ public class ValueFilterStringSlice extends StringFilter {
     }
 
     @Override
+    public void open() { }
+
+    @Override
     public String filter(String value) {
         if (Strings.isEmpty(value)) {
             return null;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterTimeFormat.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterTimeFormat.java
@@ -19,6 +19,9 @@ import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.codec.codables.SuperCodable;
 import com.addthis.hydra.data.util.TimeField;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * This {@link ValueFilter ValueFilter} <span class="hydra-summary">accepts a time string and converts the time into another format</span>.
  * <p/>
@@ -30,7 +33,7 @@ import com.addthis.hydra.data.util.TimeField;
  * @user-reference
  * @hydra-name time-format
  */
-public class ValueFilterTimeFormat extends ValueFilter implements SuperCodable {
+public class ValueFilterTimeFormat extends ValueFilter {
 
     /**
      * The input format using the
@@ -38,31 +41,45 @@ public class ValueFilterTimeFormat extends ValueFilter implements SuperCodable {
      * .html">DateTimeFormat</a>.
      * Default is "native".
      */
-    @FieldConfig(codable = true)
-    private String formatIn = "native";
+    private final String formatIn;
 
     /**
      * The input time zone. This field must be specified.
      */
-    @FieldConfig(codable = true)
-    private String timeZoneIn;
+    private final String timeZoneIn;
 
     /**
      * The output format using the
      * <a href="http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat
      * .html">DateTimeFormat</a>.
      */
-    @FieldConfig(codable = true, required = true)
-    private String formatOut;
+    private final String formatOut;
 
     /**
      * The output time zone.
      */
     @FieldConfig(codable = true)
-    private String timeZoneOut;
+    private final String timeZoneOut;
 
-    private TimeField in;
-    private TimeField out;
+    private final TimeField in;
+    private final TimeField out;
+
+
+    @JsonCreator
+    public ValueFilterTimeFormat(@JsonProperty("formatIn") String formatIn,
+                                 @JsonProperty("timeZoneIn") String timeZoneIn,
+                                 @JsonProperty(value = "formatOut", required = true) String formatOut,
+                                 @JsonProperty("timeZoneOut") String timeZoneOut) {
+        this.formatIn = formatIn;
+        this.timeZoneIn = timeZoneIn;
+        this.formatOut = formatOut;
+        this.timeZoneOut = timeZoneOut;
+        this.in = new TimeField(null, formatIn, timeZoneIn);
+        this.out = new TimeField(null, formatOut, timeZoneOut);
+    }
+
+    @Override
+    public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {
@@ -74,15 +91,4 @@ public class ValueFilterTimeFormat extends ValueFilter implements SuperCodable {
         }
     }
 
-    @Override
-    public void postDecode() {
-        in = new TimeField().setFormat(formatIn).setTimeZone(timeZoneIn);
-        out = new TimeField().setFormat(formatOut).setTimeZone(timeZoneOut);
-        in.postDecode();
-        out.postDecode();
-    }
-
-    @Override
-    public void preEncode() {
-    }
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterTrim.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterTrim.java
@@ -30,6 +30,9 @@ import com.addthis.basis.util.Strings;
 public class ValueFilterTrim extends StringFilter {
 
     @Override
+    public void open() { }
+
+    @Override
     public String filter(String value) {
         return Strings.isEmpty(value) ? value : value.trim();
     }

--- a/hydra-filters/src/main/resources/reference.conf
+++ b/hydra-filters/src/main/resources/reference.conf
@@ -33,6 +33,7 @@ plugins {
     test: BundleFilterTest
     time: BundleFilterTime
     time-range: BundleFilterTimeRange
+    try: BundleFilterTry
     url: BundleFilterURL
     value: BundleFilterValue
   }
@@ -101,4 +102,27 @@ plugins {
     delete: com.addthis.hydra.data.filter.closeablebundle.CloseableBundleFilterDelete
     set: com.addthis.hydra.data.filter.closeablebundle.CloseableBundleFilterSet
   }
+
+}
+
+com.addthis.hydra.data.filter.value.ValueFilterCounter {
+  increment: 1
+}
+
+com.addthis.hydra.data.filter.value.ValueFilterExclude {
+  urlRetries: 5
+  urlTimeout: 60000
+}
+
+com.addthis.hydra.data.filter.value.ValueFilterRequire {
+  urlRetries: 5
+  urlTimeout: 60000
+}
+
+com.addthis.hydra.data.filter.value.ValueFilterTimeFormat {
+  formatIn: "native"
+}
+
+com.addthis.hydra.data.filter.bundle.BundleFilterTimeRange {
+  defaultExit: true
 }

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterAppend.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterAppend.java
@@ -13,6 +13,7 @@
  */
 package com.addthis.hydra.data.filter.bundle;
 
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.util.map.MapBundle;
 
 import com.google.common.collect.Sets;
@@ -28,7 +29,8 @@ public class TestBundleFilterAppend {
 
     @Test
     public void fieldTest() {
-        BundleFilterAppend bfa = new BundleFilterAppend().setValues(Sets.newHashSet("foo")).setToField("bar");
+        BundleFilterAppend bfa = new BundleFilterAppend().setValues(Sets.newHashSet("foo")).setToField(
+                AutoField.newAutoField("bar"));
         MapBundle bundle = MapBundle.createBundle(new String[]{"dog", "food"});
         bfa.filter(bundle);
         assertEquals("food", bundle.get("dog"));
@@ -37,7 +39,8 @@ public class TestBundleFilterAppend {
 
     @Test
     public void fieldTest_withExistingValue() {
-        BundleFilterAppend bfa = new BundleFilterAppend().setValues(Sets.newHashSet("foo")).setToField("bar");
+        BundleFilterAppend bfa = new BundleFilterAppend().setValues(Sets.newHashSet("foo")).setToField(
+                AutoField.newAutoField("bar"));
         MapBundle bundle = MapBundle.createBundle(new String[]{"dog", "food", "bar", "car"});
         bfa.filter(bundle);
         assertEquals("food", bundle.get("dog"));
@@ -46,7 +49,8 @@ public class TestBundleFilterAppend {
 
     @Test
     public void fieldTest_multipleValues() {
-        BundleFilterAppend bfa = new BundleFilterAppend().setValues(Sets.newHashSet("car", "foo", "star")).setToField("bar").setSize(2);
+        BundleFilterAppend bfa = new BundleFilterAppend().setValues(Sets.newHashSet("car", "foo", "star"))
+                                                         .setToField(AutoField.newAutoField("bar")).setSize(2);
         MapBundle bundle = MapBundle.createBundle(new String[]{"dog", "food"});
         bfa.filter(bundle);
         assertEquals("food", bundle.get("dog"));

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterFirstValue.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterFirstValue.java
@@ -13,9 +13,14 @@
  */
 package com.addthis.hydra.data.filter.bundle;
 
+import java.io.IOException;
+
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.util.map.MapBundle;
 import com.addthis.bundle.value.ValueArray;
 import com.addthis.bundle.value.ValueFactory;
+import com.addthis.codec.config.Configs;
+import com.addthis.hydra.data.filter.bundle.unary.BundleFilterUnary;
 
 import org.junit.Test;
 
@@ -26,11 +31,11 @@ import static org.junit.Assert.assertTrue;
 public class TestBundleFilterFirstValue {
 
     @Test
-    public void testBundleFilterFirst() {
-        BundleFilterFirstValue bff = new BundleFilterFirstValue();
-        bff.setIn(new String[]{"a", "b", "c", "d"});
-        bff.setOut("out");
-
+    public void testBundleFilterFirst() throws IOException {
+        BundleFilterFirstValue bff = Configs.decodeObject(
+                BundleFilterFirstValue.class,
+                "{op:\"first\", in:[\"a\", \"b\", \"c\", \"d\"], " +
+                "out:\"out\"}");
         MapBundle b1 = MapBundle.createBundle(new String[]{
                 "a", "123",
                 "b", "234",
@@ -72,11 +77,11 @@ public class TestBundleFilterFirstValue {
     }
 
     @Test
-    public void testBundleFilterFirstWhich() {
-        BundleFilterFirstValue bff = new BundleFilterFirstValue();
-        bff.setIn(new String[]{"a", "b", "c", "d"});
-        bff.setOut("out");
-        bff.setWhich("whichField");
+    public void testBundleFilterFirstWhich() throws IOException {
+        BundleFilterFirstValue bff = Configs.decodeObject(
+                BundleFilterFirstValue.class,
+                "{op:\"first\", in:[\"a\", \"b\", \"c\", \"d\"], " +
+                "out:\"out\", which:\"whichField\"}");
 
         MapBundle b1 = MapBundle.createBundle(new String[]{
                 "a", "123",

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterMapExtract.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterMapExtract.java
@@ -15,6 +15,7 @@ package com.addthis.hydra.data.filter.bundle;
 
 import com.addthis.bundle.core.BundleFormat;
 import com.addthis.bundle.core.kvp.KVBundle;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueMap;
 
@@ -39,7 +40,7 @@ public class TestBundleFilterMapExtract {
         BundleFilterMapExtract.XMap xmap = new BundleFilterMapExtract.XMap().setFrom("foo");
         BundleFilterMapExtract.XMap[] maps = new BundleFilterMapExtract.XMap[1];
         maps[0] = xmap;
-        filter = filter.setField("map").setMap(maps);
+        filter = filter.setField(AutoField.newAutoField("map")).setMap(maps);
         assertFalse(format.hasField("foo"));
         filter.filter(bundle);
         assertTrue(format.hasField("foo"));
@@ -59,7 +60,7 @@ public class TestBundleFilterMapExtract {
         BundleFilterMapExtract.XMap xmap = new BundleFilterMapExtract.XMap().setFrom("quux");
         BundleFilterMapExtract.XMap[] maps = new BundleFilterMapExtract.XMap[1];
         maps[0] = xmap;
-        filter = filter.setField("map").setMap(maps);
+        filter = filter.setField(AutoField.newAutoField("map")).setMap(maps);
         assertFalse(format.hasField("quux"));
         filter.filter(bundle);
         assertFalse(format.hasField("quux"));
@@ -78,7 +79,7 @@ public class TestBundleFilterMapExtract {
         BundleFilterMapExtract.XMap xmap = new BundleFilterMapExtract.XMap().setFrom("quux");
         BundleFilterMapExtract.XMap[] maps = new BundleFilterMapExtract.XMap[1];
         maps[0] = xmap;
-        filter = filter.setField("map").setMap(maps);
+        filter = filter.setField(AutoField.newAutoField("map")).setMap(maps);
         assertFalse(format.hasField("quux"));
         filter.filter(bundle);
         assertFalse(format.hasField("quux"));
@@ -99,7 +100,7 @@ public class TestBundleFilterMapExtract {
         BundleFilterMapExtract.XMap xmap = new BundleFilterMapExtract.XMap().setFrom("field1").setIndirection(1);
         BundleFilterMapExtract.XMap[] maps = new BundleFilterMapExtract.XMap[1];
         maps[0] = xmap;
-        filter = filter.setField("map").setMap(maps);
+        filter = filter.setField(AutoField.newAutoField("map")).setMap(maps);
         filter.filter(bundle);
         assertEquals("a", bundle.getValue(format.getField("field1")).asString().toString());
     }
@@ -119,7 +120,7 @@ public class TestBundleFilterMapExtract {
         BundleFilterMapExtract.XMap xmap = new BundleFilterMapExtract.XMap().setFrom("field1").setIndirection(1);
         BundleFilterMapExtract.XMap[] maps = new BundleFilterMapExtract.XMap[1];
         maps[0] = xmap;
-        filter = filter.setField("map").setMap(maps);
+        filter = filter.setField(AutoField.newAutoField("map")).setMap(maps);
         filter.filter(bundle);
         assertEquals("quux", bundle.getValue(format.getField("field1")).asString().toString());
     }

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterNum.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterNum.java
@@ -27,7 +27,7 @@ public class TestBundleFilterNum {
 
     @Test
     public void testAdd() {
-        BundleFilterNum bfn = new BundleFilterNum().setDefine("c0,n3,add,v1,set");
+        BundleFilterNum bfn = new BundleFilterNum("c0,n3,add,v1,set", null);
         Bundle bundle = new ListBundle();
         bundle.setValue(bundle.getFormat().getField("c0"), ValueFactory.create(3));
         bundle.setValue(bundle.getFormat().getField("c1"), ValueFactory.create(4));
@@ -37,7 +37,7 @@ public class TestBundleFilterNum {
 
     @Test
     public void testMult() {
-        BundleFilterNum bfn = new BundleFilterNum().setDefine("c0,n3,*,v1,set");
+        BundleFilterNum bfn = new BundleFilterNum("c0,n3,*,v1,set", null);
         Bundle bundle = new ListBundle();
         bundle.setValue(bundle.getFormat().getField("c0"), ValueFactory.create(3));
         bundle.setValue(bundle.getFormat().getField("c1"), ValueFactory.create(4));
@@ -47,25 +47,25 @@ public class TestBundleFilterNum {
 
     @Test
     public void testVectorOps() {
-        BundleFilterNum bfn = new BundleFilterNum().setDefine("n1,n2,n3,n4,vector,*,v0,set");
+        BundleFilterNum bfn = new BundleFilterNum("n1,n2,n3,n4,vector,*,v0,set", null);
         Bundle bundle = new ListBundle();
         bundle.setValue(bundle.getFormat().getField("c0"), ValueFactory.create(0));
         bfn.filter(bundle);
         assertEquals("24", bundle.getValue(bundle.getFormat().getField("c0")).toString());
 
-        bfn = new BundleFilterNum().setDefine("n1,n2,n3,n4,vector,+,v0,set");
+        bfn = new BundleFilterNum("n1,n2,n3,n4,vector,+,v0,set", null);
         bundle = new ListBundle();
         bundle.setValue(bundle.getFormat().getField("c0"), ValueFactory.create(0));
         bfn.filter(bundle);
         assertEquals("10", bundle.getValue(bundle.getFormat().getField("c0")).toString());
 
-        bfn = new BundleFilterNum().setDefine("n1,n2,n3,n4,vector,min,v0,set");
+        bfn = new BundleFilterNum("n1,n2,n3,n4,vector,min,v0,set", null);
         bundle = new ListBundle();
         bundle.setValue(bundle.getFormat().getField("c0"), ValueFactory.create(0));
         bfn.filter(bundle);
         assertEquals("1", bundle.getValue(bundle.getFormat().getField("c0")).toString());
 
-        bfn = new BundleFilterNum().setDefine("n1,n2,n3,n4,vector,max,v0,set");
+        bfn = new BundleFilterNum("n1,n2,n3,n4,vector,max,v0,set", null);
         bundle = new ListBundle();
         bundle.setValue(bundle.getFormat().getField("c0"), ValueFactory.create(0));
         bfn.filter(bundle);
@@ -76,7 +76,7 @@ public class TestBundleFilterNum {
 
     @Test
     public void testInsertArrayString() {
-        BundleFilterNum bfn = new BundleFilterNum().setDefine("c0,mean,v1,set");
+        BundleFilterNum bfn = new BundleFilterNum("c0,mean,v1,set", null);
         Bundle bundle = new ListBundle();
         bundle.setValue(bundle.getFormat().getField("c0"), ValueFactory.create("1,2,3,4,5"));
         bundle.setValue(bundle.getFormat().getField("c1"), ValueFactory.create(0.0));
@@ -86,7 +86,7 @@ public class TestBundleFilterNum {
 
     @Test
     public void testInsertArrayValue() {
-        BundleFilterNum bfn = new BundleFilterNum().setDefine("a0,mean,v1,set");
+        BundleFilterNum bfn = new BundleFilterNum("a0,mean,v1,set", null);
         Bundle bundle = new ListBundle();
         ValueArray array = ValueFactory.createArray(5);
         array.add(ValueFactory.create(1));
@@ -102,7 +102,7 @@ public class TestBundleFilterNum {
 
     @Test
     public void testMean() {
-        BundleFilterNum bfn = new BundleFilterNum().setDefine("n2:3:5:7:11:13:17:19,mean,v0,set");
+        BundleFilterNum bfn = new BundleFilterNum("n2:3:5:7:11:13:17:19,mean,v0,set", null);
         Bundle bundle = new ListBundle();
         bundle.setValue(bundle.getFormat().getField("c1"), ValueFactory.create(-1));
         bfn.filter(bundle);
@@ -111,7 +111,7 @@ public class TestBundleFilterNum {
 
     @Test
     public void testVariance() {
-        BundleFilterNum bfn = new BundleFilterNum().setDefine("n2:3:5:7:11:13:17:19,variance,v0,set");
+        BundleFilterNum bfn = new BundleFilterNum("n2:3:5:7:11:13:17:19,variance,v0,set", null);
         Bundle bundle = new ListBundle();
         bundle.setValue(bundle.getFormat().getField("c1"), ValueFactory.create(-1));
         bfn.filter(bundle);
@@ -120,7 +120,7 @@ public class TestBundleFilterNum {
 
     @Test
     public void testPop() {
-        BundleFilterNum bfn = new BundleFilterNum().setDefine("n1:2:3,pop,v0,set");
+        BundleFilterNum bfn = new BundleFilterNum("n1:2:3,pop,v0,set", null);
         Bundle bundle = new ListBundle();
         bundle.setValue(bundle.getFormat().getField("c1"), ValueFactory.create(-1));
         bfn.filter(bundle);

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterRandomField.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterRandomField.java
@@ -13,7 +13,10 @@
  */
 package com.addthis.hydra.data.filter.bundle;
 
+import java.io.IOException;
+
 import com.addthis.bundle.util.map.MapBundle;
+import com.addthis.codec.config.Configs;
 
 import org.junit.Test;
 
@@ -23,16 +26,22 @@ import static org.junit.Assert.assertTrue;
 public class TestBundleFilterRandomField {
 
     @Test
-    public void fieldTest() {
-        BundleFilterRandomField bfrf = new BundleFilterRandomField(new String[]{"f0", "f1"}, "out0");
+    public void fieldTest() throws IOException {
+        BundleFilterRandomField bfrf = Configs.decodeObject(
+                BundleFilterRandomField.class,
+                "{op:\"random-field\", inFields:[\"f0\", \"f1\"], " +
+                "out:\"out0\"}");
         MapBundle bundle = MapBundle.createBundle(new String[]{"f0", "foo", "f1", "bar"});
         bfrf.filter(bundle);
         assertTrue(bundle.get("out0").equals("foo") || bundle.get("out0").equals("bar"));
     }
 
     @Test
-    public void fieldTestNull() {
-        BundleFilterRandomField bfrf = new BundleFilterRandomField(new String[]{"f0", "f1"}, "out0");
+    public void fieldTestNull() throws IOException {
+        BundleFilterRandomField bfrf = Configs.decodeObject(
+                BundleFilterRandomField.class,
+                "{op:\"random-field\", inFields:[\"f0\", \"f1\"], " +
+                "out:\"out0\"}");
         MapBundle bundle = MapBundle.createBundle(new String[]{"f0", null, "f1", "bar"});
         bfrf.filter(bundle);
         assertEquals("bar", bundle.get("out0"));

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterURL.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterURL.java
@@ -13,6 +13,7 @@
  */
 package com.addthis.hydra.data.filter.bundle;
 
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.util.map.MapBundle;
 
 import org.junit.Test;
@@ -25,7 +26,9 @@ public class TestBundleFilterURL {
 
     @Test
     public void testSetHost() {
-        BundleFilterURL filterURL = new BundleFilterURL().setField("input").setHost("host");
+        BundleFilterURL filterURL = new BundleFilterURL()
+                .setField(AutoField.newAutoField("input"))
+                .setHost(AutoField.newAutoField("host"));
         MapBundle bundle = MapBundle.createBundle(new String[]{"input", "http://www.neuron.com", "host", ""});
         assertTrue(filterURL.filter(bundle));
         assertEquals("www.neuron.com", bundle.get("host"));
@@ -33,7 +36,10 @@ public class TestBundleFilterURL {
 
     @Test
     public void testTopPrivateDomain() {
-        BundleFilterURL filterURL = new BundleFilterURL().setField("input").setHost("host").setTopPrivateDomain(true);
+        BundleFilterURL filterURL = new BundleFilterURL()
+                .setField(AutoField.newAutoField("input"))
+                .setHost(AutoField.newAutoField("host"))
+                .setTopPrivateDomain(true);
         MapBundle bundle = MapBundle.createBundle(new String[]{"input", "http://a.b.c.d.addthis.com", "host", ""});
         assertTrue(filterURL.filter(bundle));
         assertEquals("addthis.com", bundle.get("host"));
@@ -56,7 +62,10 @@ public class TestBundleFilterURL {
 
     @Test
     public void testBaseDomain() {
-        BundleFilterURL filterURL = new BundleFilterURL().setField("input").setHost("host").setBaseDomain(true);
+        BundleFilterURL filterURL = new BundleFilterURL()
+                .setField(AutoField.newAutoField("input"))
+                .setHost(AutoField.newAutoField("host"))
+                .setBaseDomain(true);
         MapBundle bundle = MapBundle.createBundle(new String[]{"input", "http://www.neuron.com", "host", ""});
         assertTrue(filterURL.filter(bundle));
         assertEquals("neuron.com", bundle.get("host"));
@@ -64,7 +73,9 @@ public class TestBundleFilterURL {
 
     @Test
     public void testFixProto() {
-        BundleFilterURL filterURL = new BundleFilterURL().setField("input").setHost("host");
+        BundleFilterURL filterURL = new BundleFilterURL()
+                .setField(AutoField.newAutoField("input"))
+                .setHost(AutoField.newAutoField("host"));;
         MapBundle bundle = MapBundle.createBundle(new String[]{"input", "www.neuron.com", "host", ""});
         assertFalse(filterURL.filter(bundle));
         filterURL.setFixProto(true);
@@ -95,7 +106,9 @@ public class TestBundleFilterURL {
 
         assertEquals(testInput.length, expectedOutput.length);
         for (int i = 0; i < testInput.length; i++) {
-            BundleFilterURL filterURL = new BundleFilterURL().setField("input").setHostNormal("host");
+            BundleFilterURL filterURL = new BundleFilterURL()
+                    .setField(AutoField.newAutoField("input"))
+                    .setHostNormal(AutoField.newAutoField("host"));;
             String[] input = new String[]{"input", null, "host", ""};
             input[1] = "http://" + testInput[i];
             MapBundle bundle = MapBundle.createBundle(input);

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterValue.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/bundle/TestBundleFilterValue.java
@@ -13,6 +13,7 @@
  */
 package com.addthis.hydra.data.filter.bundle;
 
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.util.map.MapBundle;
 
 import org.junit.Test;
@@ -24,7 +25,7 @@ public class TestBundleFilterValue {
 
     @Test
     public void fieldTest() {
-        BundleFilterValue bfv = new BundleFilterValue().setValue("foo").setToField("car");
+        BundleFilterValue bfv = new BundleFilterValue().setValue("foo").setToField(AutoField.newAutoField("car"));
         MapBundle bundle = MapBundle.createBundle(new String[]{"dog", "food"});
         bfv.filter(bundle);
         assertEquals(bundle.get("dog"), "food");

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterCounter.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterCounter.java
@@ -77,7 +77,7 @@ public class TestValueFilterCounter {
 
     @Test
     public void singleThreadedCounter() {
-        ValueFilterCounter counter = new ValueFilterCounter();
+        ValueFilterCounter counter = new ValueFilterCounter(null, 0, 1, 0);
         Thread thread = new CounterThread(counter, 1000000);
         thread.start();
         try {
@@ -92,7 +92,7 @@ public class TestValueFilterCounter {
 
     @Test
     public void multiThreadedCounter() {
-        ValueFilterCounter counter = new ValueFilterCounter();
+        ValueFilterCounter counter = new ValueFilterCounter(null, 0, 1, 0);
         Thread thread1 = new CounterThread(counter, 1000000);
         Thread thread2 = new CounterThread(counter, 1000000);
         Thread thread3 = new CounterThread(counter, 1000000);

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterExclude.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterExclude.java
@@ -15,6 +15,8 @@ package com.addthis.hydra.data.filter.value;
 
 import java.util.HashSet;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -23,7 +25,17 @@ public class TestValueFilterExclude {
 
     // TODO: Reduce ridiculous duplication with ValueFilterRequire
     private String excludeFilter(String val, HashSet<String> exactValues, HashSet<String> match, HashSet<String> find, String[] contains) {
-        return new ValueFilterExclude().setValue(exactValues).setMatch(match).setContains(contains).setFind(find).filter(val);
+        return new ValueFilterExclude(
+                exactValues,
+                null,
+                match,
+                null,
+                find,
+                null,
+                contains,
+                null,
+                0,
+                0).filter(val);
     }
 
     @Test

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterRegex.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterRegex.java
@@ -13,6 +13,8 @@
  */
 package com.addthis.hydra.data.filter.value;
 
+import java.util.regex.Pattern;
+
 import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueObject;
 
@@ -25,7 +27,7 @@ public class TestValueFilterRegex {
 
     @Test
     public void akamaiGroup() {
-        ValueFilterRegex vf = new ValueFilterRegex().setPattern("Log_([0-9]+)\\.");
+        ValueFilterRegex vf = new ValueFilterRegex().setPattern(Pattern.compile("Log_([0-9]+)\\."));
         ValueObject res = vf.filter(ValueFactory.create("stream://san1.local:8614/split/logs/12345/2011/05/20/aLog_12345.esw3c_U.201105200000-0100-1.gz"));
         assertTrue(res != null);
         assertTrue(res.asArray().size() > 0);

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterReplace.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterReplace.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 public class TestValueFilterReplace {
 
     private String replaceFilter(String val, String find, String replace, boolean regex) {
-        return new ValueFilterReplace().setFind(find).setReplace(replace).setRegex(regex).filter(val);
+        return new ValueFilterReplace(find, replace, regex).filter(val);
     }
 
     @Test

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterRequire.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterRequire.java
@@ -15,6 +15,8 @@ package com.addthis.hydra.data.filter.value;
 
 import java.util.HashSet;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -22,7 +24,19 @@ import static org.junit.Assert.assertEquals;
 public class TestValueFilterRequire {
 
     private String requireFilter(String val, HashSet<String> exactValues, HashSet<String> match, HashSet<String> find, String[] contains) {
-        return new ValueFilterRequire().setValue(exactValues).setMatch(match).setContains(contains).setFind(find).filter(val);
+        return new ValueFilterRequire(
+                exactValues,
+                null,
+                match,
+                null,
+                find,
+                null,
+                contains,
+                null,
+                false,
+                false,
+                0,
+                0).filter(val);
     }
 
     @Test

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterReverse.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterReverse.java
@@ -13,6 +13,8 @@
  */
 package com.addthis.hydra.data.filter.value;
 
+import java.util.Objects;
+
 import com.addthis.bundle.util.ValueUtil;
 import com.addthis.bundle.value.ValueArray;
 import com.addthis.bundle.value.ValueFactory;
@@ -77,9 +79,12 @@ public class TestValueFilterReverse {
         ValueArray arr = create(new ValueObject[]{ValueFactory.create("a"), ValueFactory.create("b"), ValueFactory.create("c")});
         ValueArray expt = create(new ValueObject[]{ValueFactory.create("c"), ValueFactory.create("b"), ValueFactory.create("a")});
         ValueObject rev = filter(arr);
-        //System.out.println(expt);
-        //System.out.println(rev);
-        assertTrue(ValueUtil.isEqual(expt, rev));
+        assertTrue(Objects.equals(expt, rev));
+        arr = create(new ValueObject[]{ValueFactory.create("a"), ValueFactory.create("b")});
+        expt = create(new ValueObject[]{ValueFactory.create("b"), ValueFactory.create("a")});
+        rev = filter(arr);
+        assertTrue(Objects.equals(expt, rev));
+
     }
 
     @Test
@@ -87,9 +92,7 @@ public class TestValueFilterReverse {
         ValueArray arr = create(new ValueObject[]{ValueFactory.create("foo"), ValueFactory.create("bar"), ValueFactory.create("bax")});
         ValueArray expt = create(new ValueObject[]{ValueFactory.create("oof"), ValueFactory.create("rab"), ValueFactory.create("xab")});
         ValueObject rev = filterEach(arr);
-        System.out.println(expt);
-        System.out.println(rev);
-        assertTrue(ValueUtil.isEqual(expt, rev));
+        assertTrue(Objects.equals(expt, rev));
     }
 
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/MapDef.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/MapDef.java
@@ -61,4 +61,13 @@ public final class MapDef {
 
     /** The mapping of fields from the input source into the bundle. */
     @JsonProperty FieldFilter[] fields;
+
+    public void init() {
+        if (filterIn != null) {
+            filterIn.open();
+        }
+        if (filterOut != null) {
+            filterOut.open();
+        }
+    }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamMapper.java
@@ -135,6 +135,7 @@ public class StreamMapper implements StreamEmitter, TaskRunnable {
     @Override
     public void start() {
         source.init();
+        map.init();
         output.init();
         if (builder != null) {
             builder.init();

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
@@ -370,7 +370,7 @@ public final class TreeMapper extends DataOutputTypeList implements Codable {
     private long getBundleTime(Bundle bundle) {
         long bundleTime = JitterClock.globalTime();
         if (timeField != null) {
-            ValueObject vo = bundle.getValue(bundle.getFormat().getField(timeField.getField()));
+            ValueObject vo = timeField.getField().getValue(bundle);
             if (vo == null) {
                 log.debug("missing time {} in [{}] --> {}", timeField.getField(), bundle.getCount(), bundle);
             } else {


### PR DESCRIPTION
Bundle filters and value filters have a lazy initialization
mechanism that is poorly implemented and a bad design.
A developer writing a new filter must remember to
explicitly call the initialization method and it is
also possible to invoke other filters and bypass
the initialization.

In this implementation all filters have an open()
method. The application is responsible for ensuring
that open() is called before using the filter.

In this implementation the majority of initialization
is be performed in the constructor. Any initialization
that is too expensive to perform when the object
is deserialized (such as accessing the network or
the filesystem) should be placed in the open() method.
The use of SuperCodable for filters is discouraged.