### PR TITLE
Allow PathQuery#childMatch to return map of values.

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/query/FieldValueList.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/query/FieldValueList.java
@@ -22,6 +22,7 @@ import com.addthis.bundle.core.BundleFormat;
 import com.addthis.bundle.core.BundleFormatted;
 import com.addthis.bundle.value.ValueArray;
 import com.addthis.bundle.value.ValueFactory;
+import com.addthis.bundle.value.ValueMap;
 import com.addthis.bundle.value.ValueObject;
 
 
@@ -80,7 +81,7 @@ public class FieldValueList implements BundleFormatted {
         return list.size() > 0;
     }
 
-    public boolean updateBundleWithAppend(Bundle bundle) {
+    public boolean updateBundleWithListAppend(Bundle bundle) {
         for (FieldValue fv : list) {
             ValueObject oldValue = bundle.getValue(fv.field);
             ValueArray newValue;
@@ -93,6 +94,24 @@ public class FieldValueList implements BundleFormatted {
                 newValue.add(oldValue);
             }
             newValue.add(fv.value);
+            bundle.setValue(fv.field, newValue);
+        }
+        return !list.isEmpty();
+    }
+
+    public boolean updateBundleWithMapAppend(Bundle bundle) {
+        for (FieldValue fv : list) {
+            ValueObject oldValue = bundle.getValue(fv.field);
+            ValueMap newValue;
+            if (oldValue == null) {
+                newValue = ValueFactory.createMap();
+            } else if (oldValue instanceof ValueMap) {
+                newValue = (ValueMap) oldValue;
+            } else {
+                newValue = ValueFactory.createMap();
+                newValue.put(oldValue.asString().asNative(), oldValue);
+            }
+            newValue.put(fv.value.asString().asNative(), fv.value);
             bundle.setValue(fv.field, newValue);
         }
         return !list.isEmpty();

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathQuery.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathQuery.java
@@ -185,7 +185,7 @@ public final class PathQuery extends PathOp {
                     updated = valueList.updateBundle(state.getBundle());
                     break;
                 default:
-                    throw new IllegalStateException("Known childMatch value " + childMatch);
+                    throw new IllegalStateException("Unknown childMatch value " + childMatch);
             }
             if (updated) {
                 if (debug > 0) {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathQuery.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathQuery.java
@@ -83,17 +83,22 @@ public final class PathQuery extends PathOp {
     private String debugKey;
 
     /**
-     * If true then process all the children of the node
+     * Optionally process all the children of the node
      * that we have matched against. Append all the matching results
-     * into value arrays. Default is false.
+     * into either an array or a map. Possible values are
+     * "AS_LIST" and "AS_MAP". Default is null.
      */
     @FieldConfig(codable = true)
-    private boolean childMatch;
+    private ChildMatch childMatch;
 
     private int match;
     private int miss;
 
     public PathQuery() {
+    }
+
+    public static enum ChildMatch {
+        AS_LIST, AS_MAP
     }
 
     @Override
@@ -137,7 +142,7 @@ public final class PathQuery extends PathOp {
             return null;
         }
         boolean updated = false;
-        if (childMatch) {
+        if (childMatch != null) {
             ClosableIterator<DataTreeNode> children = null;
             try {
                 children = reference.getIterator();
@@ -167,8 +172,10 @@ public final class PathQuery extends PathOp {
             if (values.update(valueList, reference, state) == 0) {
                 return false;
             }
-            if (childMatch) {
-                updated = valueList.updateBundleWithAppend(state.getBundle());
+            if (childMatch == ChildMatch.AS_LIST) {
+                updated = valueList.updateBundleWithListAppend(state.getBundle());
+            } else if (childMatch == ChildMatch.AS_MAP) {
+                updated = valueList.updateBundleWithMapAppend(state.getBundle());
             } else {
                 updated = valueList.updateBundle(state.getBundle());
             }


### PR DESCRIPTION
Replace the PathQuery#childMatch boolean flag with an enum field.
The existing behavior will return a list of values if childMatch is true.
In the new behavior childMatch can return either a list or a map.
Providing this feature speeds up my job by x5 for its particular
use-case of childMatch by allowing for the deletion of a specific
key without iterating through all the elements.