### PR TITLE
Complete filter initialization is now explicit. Ref T51853.

### DIFF
--- a/hydra-avro/src/main/java/com/addthis/hydra/task/output/OutputStreamAvro.java
+++ b/hydra-avro/src/main/java/com/addthis/hydra/task/output/OutputStreamAvro.java
@@ -79,6 +79,9 @@ public class OutputStreamAvro extends OutputStreamFormatter {
     }
 
     @Override
+    public void open() { }
+
+    @Override
     public OutputStreamEmitter createEmitter() {
         return new OutputStreamEmitter() {
             private BinaryEncoder encoder;

--- a/hydra-avro/src/main/java/com/addthis/hydra/task/source/DataSourceAvro.java
+++ b/hydra-avro/src/main/java/com/addthis/hydra/task/source/DataSourceAvro.java
@@ -80,6 +80,9 @@ public class DataSourceAvro extends BundleizerFactory {
         datumReader = new GenericDatumReader<>(inputSchema);
     }
 
+    @Override
+    public void open() { }
+
     public static ValueObject getValueObject(GenericRecord genericRecord,
                                                 Schema.Field field,
                                                 GenericData genericData) throws IOException {

--- a/hydra-data/src/main/java/com/addthis/hydra/data/query/op/OpFilter.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/query/op/OpFilter.java
@@ -34,6 +34,7 @@ public class OpFilter extends AbstractRowOp {
         super(queryPromise);
         try {
             filter = decodeObject(BundleFilter.class, args);
+            filter.open();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataCopy.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataCopy.java
@@ -94,6 +94,11 @@ public final class DataCopy extends TreeNodeData<DataCopy.Config> {
             for (Entry<String, String> s : conf.key.entrySet()) {
                 keyAccess.put(s.getKey(), p.getFormat().getField(s.getValue()));
             }
+            if (conf.op != null) {
+                for (ValueFilter filter : conf.op.values()) {
+                    filter.open();
+                }
+            }
         }
         // copy values from pipeline
         for (Entry<String, BundleField> s : keyAccess.entrySet()) {

--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataKeyTop.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataKeyTop.java
@@ -160,6 +160,9 @@ public class DataKeyTop extends TreeNodeData<DataKeyTop.Config> implements Codab
         if (keyAccess == null) {
             keyAccess = state.getBundle().getFormat().getField(conf.key);
             filter = conf.filter;
+            if (filter != null) {
+                filter.open();
+            }
         }
         ValueObject val = state.getBundle().getValue(keyAccess);
         if (val != null) {

--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataKeyTop.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataKeyTop.java
@@ -21,7 +21,7 @@ import java.util.Map.Entry;
 import com.addthis.basis.util.Strings;
 import com.addthis.basis.util.Varint;
 
-import com.addthis.bundle.core.BundleField;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
@@ -114,7 +114,7 @@ public class DataKeyTop extends TreeNodeData<DataKeyTop.Config> implements Codab
          * This field is required.
          */
         @FieldConfig(codable = true, required = true)
-        private String key;
+        private AutoField key;
 
         /**
          * Maximum capacity of the key topper.
@@ -153,18 +153,18 @@ public class DataKeyTop extends TreeNodeData<DataKeyTop.Config> implements Codab
     private int size;
 
     private ValueFilter filter;
-    private BundleField keyAccess;
+    private AutoField keyAccess;
 
     @Override
     public boolean updateChildData(DataTreeNodeUpdater state, DataTreeNode childNode, DataKeyTop.Config conf) {
         if (keyAccess == null) {
-            keyAccess = state.getBundle().getFormat().getField(conf.key);
+            keyAccess = conf.key;
             filter = conf.filter;
             if (filter != null) {
                 filter.open();
             }
         }
-        ValueObject val = state.getBundle().getValue(keyAccess);
+        ValueObject val = keyAccess.getValue(state.getBundle());
         if (val != null) {
             if (filter != null) {
                 val = filter.filter(val);

--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataPercentileDistribution.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataPercentileDistribution.java
@@ -73,7 +73,7 @@ public class DataPercentileDistribution extends TreeNodeData<DataPercentileDistr
          * Name of the field to monitor. This field is required.
          */
         @FieldConfig(codable = true, required = true)
-        private AutoField key;
+        private String key;
 
         /**
          * Sample size. Default is 1024.
@@ -100,7 +100,7 @@ public class DataPercentileDistribution extends TreeNodeData<DataPercentileDistr
 
 
     @FieldConfig(codable = true)
-    private AutoField key;
+    private String key;
     @FieldConfig(codable = true)
     private ValueFilter filter;
     @FieldConfig(codable = true)
@@ -111,7 +111,7 @@ public class DataPercentileDistribution extends TreeNodeData<DataPercentileDistr
     @Override
     public boolean updateChildData(DataTreeNodeUpdater state, DataTreeNode childNode, Config conf) {
         if (keyAccess == null) {
-            keyAccess = conf.key;
+            keyAccess = AutoField.newAutoField(conf.key);
             filter = conf.filter;
             if (filter != null) {
                 filter.open();

--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataPercentileDistribution.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataPercentileDistribution.java
@@ -16,7 +16,7 @@ package com.addthis.hydra.data.tree.prop;
 import java.util.Arrays;
 import java.util.List;
 
-import com.addthis.bundle.core.BundleField;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.util.ValueUtil;
 import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueObject;
@@ -73,7 +73,7 @@ public class DataPercentileDistribution extends TreeNodeData<DataPercentileDistr
          * Name of the field to monitor. This field is required.
          */
         @FieldConfig(codable = true, required = true)
-        private String key;
+        private AutoField key;
 
         /**
          * Sample size. Default is 1024.
@@ -100,24 +100,24 @@ public class DataPercentileDistribution extends TreeNodeData<DataPercentileDistr
 
 
     @FieldConfig(codable = true)
-    private String key;
+    private AutoField key;
     @FieldConfig(codable = true)
     private ValueFilter filter;
     @FieldConfig(codable = true)
     private KeyPercentileDistribution histogram;
 
-    private BundleField keyAccess;
+    private AutoField keyAccess;
 
     @Override
     public boolean updateChildData(DataTreeNodeUpdater state, DataTreeNode childNode, Config conf) {
         if (keyAccess == null) {
-            keyAccess = state.getBundle().getFormat().getField(conf.key);
+            keyAccess = conf.key;
             filter = conf.filter;
             if (filter != null) {
                 filter.open();
             }
         }
-        ValueObject val = state.getBundle().getValue(keyAccess);
+        ValueObject val = keyAccess.getValue(state.getBundle());
         if (val != null) {
             if (filter != null) {
                 val = filter.filter(val);

--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataPercentileDistribution.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataPercentileDistribution.java
@@ -113,6 +113,9 @@ public class DataPercentileDistribution extends TreeNodeData<DataPercentileDistr
         if (keyAccess == null) {
             keyAccess = state.getBundle().getFormat().getField(conf.key);
             filter = conf.filter;
+            if (filter != null) {
+                filter.open();
+            }
         }
         ValueObject val = state.getBundle().getValue(keyAccess);
         if (val != null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterMapExtract.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterMapExtract.java
@@ -73,7 +73,15 @@ public class BundleFilterMapExtract extends BundleFilter {
     private XMap[] map;
 
     @Override
-    public void open() { }
+    public void open() {
+        if (map != null) {
+            for (XMap mapping : map) {
+                if (mapping.filter != null) {
+                    mapping.filter.open();
+                }
+            }
+        }
+    }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/alert/JobAlertUtil.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/alert/JobAlertUtil.java
@@ -190,6 +190,7 @@ public class JobAlertUtil {
         BundleFilter bFilter = null;
         try {
             bFilter = CodecJSON.decodeString(BundleFilter.class, filter);
+            bFilter.open();
         } catch (Exception ex) {
             errorBuilder.append("Error attempting to create bundle filter: " + ex + "\n");
             log.error("Error attempting to create bundle filter", ex);

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/CloseableBundleFilterStreamBuilder.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/CloseableBundleFilterStreamBuilder.java
@@ -36,6 +36,9 @@ public class CloseableBundleFilterStreamBuilder extends StreamBuilder {
 
     @Override
     public void init() {
+        if (cfilter != null) {
+            cfilter.open();
+        }
     }
 
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/EachStreamBuilder.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/EachStreamBuilder.java
@@ -34,7 +34,9 @@ public class EachStreamBuilder extends StreamBuilder {
 
     @Override
     public void init() {
-        // no init for this builder
+        if (emitFilter != null) {
+            emitFilter.open();
+        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/FieldFilter.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/FieldFilter.java
@@ -63,6 +63,12 @@ public final class FieldFilter {
         }
     }
 
+    public void open() {
+        if (filter != null) {
+            filter.open();
+        }
+    }
+
     // can't find a good way to copy the json value for "from", copy constructors fail for abstract types,
     // and clone has its own host of problems. We could just re-use the same object, but that would be even
     // more wasteful than the caching we perform for unchanging formats. This is a decent stop-gap solution.

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/MapDef.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/MapDef.java
@@ -69,5 +69,10 @@ public final class MapDef {
         if (filterOut != null) {
             filterOut.open();
         }
+        if (fields != null) {
+            for(FieldFilter field : fields) {
+                field.open();
+            }
+        }
     }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/SortedDeDupBuilder.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/SortedDeDupBuilder.java
@@ -53,6 +53,9 @@ public class SortedDeDupBuilder extends StreamBuilder {
 
     @Override
     public void init() {
+        if (filter != null) {
+            filter.open();
+        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamRowSplitBuilder.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamRowSplitBuilder.java
@@ -34,6 +34,9 @@ public class StreamRowSplitBuilder extends StreamBuilder {
 
     @Override
     public void init() {
+        if (filter != null) {
+            filter.open();
+        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractDataOutput.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractDataOutput.java
@@ -82,7 +82,9 @@ public abstract class AbstractDataOutput extends DataOutputTypeList {
         if (writer != null) {
             writer.open();
         }
-
+        if (filter != null) {
+            filter.open();
+        }
         if (dataPurgeConfig != null) {
             purgeData();
         }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractFilteredOutput.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractFilteredOutput.java
@@ -23,6 +23,13 @@ public abstract class AbstractFilteredOutput extends TaskDataOutput {
 
     @JsonProperty protected BundleFilter filter;
 
+    @Override
+    protected void open() {
+        if (filter != null) {
+            filter.open();
+        }
+    }
+
     public boolean filter(Bundle bundle) {
         return (filter == null) || filter.filter(bundle);
     }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractOutputWriter.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractOutputWriter.java
@@ -166,6 +166,15 @@ public abstract class AbstractOutputWriter {
     }
 
     public void open() {
+
+        if (format != null) {
+            format.open();
+        }
+
+        if (filter != null) {
+            filter.open();
+        }
+
         /**
          * The next several lines of logic are to handle
          * ridiculous input values for maxBundles and bufferSizeRatio.

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/FilteredDataOutput.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/FilteredDataOutput.java
@@ -49,6 +49,9 @@ public class FilteredDataOutput extends TaskDataOutput {
 
     @Override
     protected void open() {
+        if (filter != null) {
+            filter.open();
+        }
         output.open();
     }
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/GangliaOutput.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/GangliaOutput.java
@@ -78,6 +78,7 @@ public final class GangliaOutput extends AbstractFilteredOutput {
     }
 
     @Override protected void open() {
+        super.open();
         checkState(gmetrics == null, "open was already called");
         log.info("opening ganglia output with hosts: {}", hostsToString());
         gmetrics = hosts.stream().map(hostPort -> {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputStreamChannel.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputStreamChannel.java
@@ -38,6 +38,9 @@ public class OutputStreamChannel extends OutputStreamFormatter {
     private HashSet<String> exclude;
 
     @Override
+    public void open() { }
+
+    @Override
     public OutputStreamEmitter createEmitter() {
         return new OutputStreamEmitter() {
             private final ClassIndexMap classMap = DataChannelCodec.createClassIndexMap();

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputStreamColumnized.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputStreamColumnized.java
@@ -53,6 +53,13 @@ public class OutputStreamColumnized extends OutputStreamFormatter implements Sup
     private byte[] eolB;
 
     @Override
+    public void open() {
+        if (filter != null) {
+            filter.open();
+        }
+    }
+
+    @Override
     public OutputStreamEmitter createEmitter() {
         return new TokenOut();
     }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputStreamFormatter.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputStreamFormatter.java
@@ -28,4 +28,5 @@ public abstract class OutputStreamFormatter {
 
     public abstract OutputStreamEmitter createEmitter();
 
+    public abstract void open();
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputStreamJson.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputStreamJson.java
@@ -29,6 +29,9 @@ import com.addthis.maljson.JSONObject;
  */
 public class OutputStreamJson extends OutputStreamFormatter implements Codable {
 
+    @Override
+    public void open() { }
+
     private static final byte[] newlineBytes = "\n".getBytes(StandardCharsets.UTF_8);
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputStreamNoop.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputStreamNoop.java
@@ -25,6 +25,9 @@ import com.addthis.bundle.core.Bundle;
 public class OutputStreamNoop extends OutputStreamFormatter {
 
     @Override
+    public void open() { }
+
+    @Override
     public OutputStreamEmitter createEmitter() {
         return new NoopOut();
     }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathElement.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathElement.java
@@ -192,6 +192,9 @@ public abstract class PathElement implements Codable, TreeDataParent {
             label = new PathValue(intern(name));
             label.count = count;
         }
+        if (filter != null) {
+            filter.open();
+        }
     }
 
     public final boolean isOp() {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathFile.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathFile.java
@@ -139,6 +139,9 @@ public final class PathFile extends PathKeyValue {
             }
             tokens = new Tokenizer().setSeparator(separator).setPacking(true);
         }
+        if (tokenFilter != null) {
+            tokenFilter.open();
+        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathKeyValue.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathKeyValue.java
@@ -75,6 +75,9 @@ public class PathKeyValue extends PathValue {
     public void resolve(TreeMapper mapper) {
         super.resolve(mapper);
         keyAccess = mapper.bindField(key);
+        if (prefilter != null) {
+            prefilter.open();
+        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathValue.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathValue.java
@@ -128,6 +128,9 @@ public class PathValue extends PathElement {
         if (each != null) {
             each.resolve(mapper);
         }
+        if (vfilter != null) {
+            vfilter.open();
+        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/AbstractStreamFileDataSource.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/AbstractStreamFileDataSource.java
@@ -311,6 +311,9 @@ public abstract class AbstractStreamFileDataSource extends TaskDataSource implem
         if (shards == null) {
             shards = config.calcShardList(shardTotal);
         }
+        if (format != null) {
+            format.open();
+        }
         PersistentStreamFileSource persistentStreamFileSource = getSource();
         source = persistentStreamFileSource;
         if (!processAllData &&
@@ -324,6 +327,7 @@ public abstract class AbstractStreamFileDataSource extends TaskDataSource implem
                 persistentStreamFileSource.init(getMarkDirFile(), shards);
             }
             if (filter != null) {
+                filter.open();
                 setSource(new StreamSourceFiltered(source, filter));
             }
             if (hash) {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceFiltered.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceFiltered.java
@@ -78,6 +78,9 @@ public class DataSourceFiltered extends TaskDataSource {
 
     @Override
     public void init() {
+        if (filter != null) {
+            filter.open();
+        }
         stream.init();
     }
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/StreamTokenizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/StreamTokenizer.java
@@ -43,6 +43,15 @@ public class StreamTokenizer extends Tokenizer {
         return this;
     }
 
+    @Override
+    public Tokenizer initialize() {
+        super.initialize();
+        if (filter != null) {
+            filter.open();
+        }
+        return this;
+    }
+
     /**
      * updated after each call to nextLine.
      *

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/BundleizerFactory.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/BundleizerFactory.java
@@ -33,5 +33,7 @@ import com.addthis.codec.codables.Codable;
 @Pluggable("stream-bundleizer")
 public abstract class BundleizerFactory implements Codable {
 
+    public abstract void open();
+
     public abstract Bundleizer createBundleizer(InputStream input, BundleFactory factory);
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/ChannelBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/ChannelBundleizer.java
@@ -30,6 +30,9 @@ import com.addthis.bundle.io.DataChannelReader;
 public class ChannelBundleizer extends BundleizerFactory {
 
     @Override
+    public void open() { }
+
+    @Override
     public Bundleizer createBundleizer(final InputStream input, final BundleFactory factory) {
         return new Bundleizer() {
             private final DataChannelReader reader = new DataChannelReader(factory, input);

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/ColumnBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/ColumnBundleizer.java
@@ -39,6 +39,7 @@ public class ColumnBundleizer extends NewlineBundleizer {
 
     @Override
     public void open() {
+        super.open();
         if (tokenFilter != null) {
             tokenFilter.open();
         }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/ColumnBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/ColumnBundleizer.java
@@ -38,6 +38,13 @@ public class ColumnBundleizer extends NewlineBundleizer {
     private ValueFilter tokenFilter;
 
     @Override
+    public void open() {
+        if (tokenFilter != null) {
+            tokenFilter.open();
+        }
+    }
+
+    @Override
     public Bundle bundleize(Bundle next, String line) {
         List<String> row = tokens.tokenize(line);
         if (row == null) {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/GsonBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/GsonBundleizer.java
@@ -41,6 +41,9 @@ import com.google.gson.stream.JsonReader;
 public class GsonBundleizer extends BundleizerFactory {
 
     @Override
+    public void open() { }
+
+    @Override
     public Bundleizer createBundleizer(final InputStream inputArg, final BundleFactory factoryArg) {
         return new Bundleizer() {
             private final BundleFactory factory = factoryArg;

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/JSONBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/JSONBundleizer.java
@@ -27,6 +27,9 @@ import com.addthis.maljson.JSONObject;
 public class JSONBundleizer extends NewlineBundleizer {
 
     @Override
+    public void open() { }
+
+    @Override
     public Bundle bundleize(Bundle next, String line) {
         BundleFormat format = next.getFormat();
         try {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/JSONBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/JSONBundleizer.java
@@ -27,9 +27,6 @@ import com.addthis.maljson.JSONObject;
 public class JSONBundleizer extends NewlineBundleizer {
 
     @Override
-    public void open() { super.open(); }
-
-    @Override
     public Bundle bundleize(Bundle next, String line) {
         BundleFormat format = next.getFormat();
         try {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/JSONBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/JSONBundleizer.java
@@ -27,7 +27,7 @@ import com.addthis.maljson.JSONObject;
 public class JSONBundleizer extends NewlineBundleizer {
 
     @Override
-    public void open() { }
+    public void open() { super.open(); }
 
     @Override
     public Bundle bundleize(Bundle next, String line) {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/KVBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/KVBundleizer.java
@@ -44,6 +44,4 @@ public class KVBundleizer extends NewlineBundleizer {
         return next;
     }
 
-    @Override
-    public void open() { super.open(); }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/KVBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/KVBundleizer.java
@@ -45,5 +45,5 @@ public class KVBundleizer extends NewlineBundleizer {
     }
 
     @Override
-    public void open() { }
+    public void open() { super.open(); }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/KVBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/KVBundleizer.java
@@ -43,4 +43,7 @@ public class KVBundleizer extends NewlineBundleizer {
         next.setValue(format.getField(kv.getKey()), ValueFactory.create(kv.getValue()));
         return next;
     }
+
+    @Override
+    public void open() { }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/NewlineBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/NewlineBundleizer.java
@@ -35,6 +35,13 @@ public abstract class NewlineBundleizer extends BundleizerFactory {
     private ValueFilter lineFilter;
 
     @Override
+    public void open() {
+        if (lineFilter != null) {
+            lineFilter.open();
+        }
+    }
+
+    @Override
     public Bundleizer createBundleizer(final InputStream inputArg, final BundleFactory factoryArg) {
         return new Bundleizer() {
             private final BufferedReader reader = new BufferedReader(new InputStreamReader(inputArg), 65535);


### PR DESCRIPTION
Remaining instances where new filter initialization needs to be invoked. Replaced BundleField with AutoFields in data attachments. In cases where the field name is only serialized in the configuration object, we can replace the String type with the AutoField type. In cases where we are serializing the field name in the data attachment itself (the binary representation) we probably shouldn't be doing this but it is out of scope to fix that behavior so we preserve the type as a String and use AutoField.createNewField().