### PR TITLE
Implement 'maxNodes' to PathValue and derivatives.

### DIFF
--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapState.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapState.java
@@ -135,6 +135,10 @@ public final class TreeMapState implements DataTreeNodeUpdater, DataTreeNodeInit
         return stack.pop();
     }
 
+    public int getNodeCount() {
+        return current().getNodeCount();
+    }
+
     public void push(TreeNodeList tnl) {
         if (tnl.size() == 1) {
             push(tnl.get(0));
@@ -254,7 +258,7 @@ public final class TreeMapState implements DataTreeNodeUpdater, DataTreeNodeInit
      */
     public TreeNodeList processPathElement(PathElement pe) {
         if (profiling) {
-            long mark = profiling ? System.nanoTime() : 0;
+            long mark = System.nanoTime();
             TreeNodeList list = processPathElementProfiled(pe);
             processor.updateProfile(pe, System.nanoTime() - mark);
             return list;


### PR DESCRIPTION
Optionally specify the maximum number of children nodes that can be created in a subtree. Several one line changes to remove redundant code.

This is a fairly small change in terms of LoC but it affects one of the core components of Hydra jobs so it is more appropriate as a pull request.
