### PR TITLE
Preempt prune/deletion operations

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/DataTree.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/DataTree.java
@@ -15,6 +15,8 @@ package com.addthis.hydra.data.tree;
 
 import java.io.IOException;
 
+import java.util.function.BooleanSupplier;
+
 import com.addthis.hydra.store.db.CloseOperation;
 
 public interface DataTree extends DataTreeNode {
@@ -36,4 +38,16 @@ public interface DataTree extends DataTreeNode {
     public int getCacheSize();
 
     public double getCacheHitRate();
+
+    /**
+     * Delete from the backing storage all nodes that have been moved to be
+     * children of the trash node where they are waiting deletion. Also delete
+     * all subtrees of these nodes. After deleting each subtree then test
+     * the provided {@param terminationCondition}. If it returns true then
+     * stop deletion.
+     *
+     * @param terminationCondition invoked between subtree deletions to
+     *                             determine whether to return from method.
+     */
+    public void foregroundNodeDeletion(BooleanSupplier terminationCondition);
 }

--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/ReadTree.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/ReadTree.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 
 import com.addthis.basis.util.ClosableIterator;
 import com.addthis.basis.util.Parameter;
@@ -500,6 +501,11 @@ public final class ReadTree implements DataTree {
     void testIntegrity() {
         ReadExternalPagedStore store = source.getReadEps();
         store.testIntegrity();
+    }
+
+    @Override
+    public void foregroundNodeDeletion(BooleanSupplier terminationCondition) {
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/hydra-data/src/test/java/com/addthis/hydra/data/tree/concurrent/TestConcurrentTree.java
+++ b/hydra-data/src/test/java/com/addthis/hydra/data/tree/concurrent/TestConcurrentTree.java
@@ -212,6 +212,9 @@ public class TestConcurrentTree {
 
             tree.deleteNode(root, "hello");
             tree.waitOnDeletions();
+            tree.close();
+            tree = new Builder(dir).build();
+            tree.foregroundNodeDeletion(() -> false);
             assertEquals(2, tree.getCache().size());
             assertEquals(0, root.getNodeCount());
             assertEquals(1, tree.getTreeTrashNode().getNodeCount());
@@ -253,6 +256,9 @@ public class TestConcurrentTree {
             }
 
             tree.waitOnDeletions();
+            tree.close();
+            tree = new Builder(dir).build();
+            tree.foregroundNodeDeletion(() -> false);
             assertEquals(2, tree.getCache().size());
             assertEquals(0, root.getNodeCount());
 
@@ -360,6 +366,9 @@ public class TestConcurrentTree {
                 assertNull(node);
             }
             tree.waitOnDeletions();
+            tree.close();
+            tree = new Builder(dir).build();
+            tree.foregroundNodeDeletion(() -> false);
             assertEquals(1000, tree.getTreeTrashNode().getCounter());
             assertEquals(1000, tree.getTreeTrashNode().getNodeCount());
             tree.close(false, close);
@@ -496,6 +505,9 @@ public class TestConcurrentTree {
                 assertNull(node);
             }
             tree.waitOnDeletions();
+            tree.close();
+            tree = new Builder(dir).build();
+            tree.foregroundNodeDeletion(() -> false);
             assertEquals(numElements, tree.getTreeTrashNode().getCounter());
             assertEquals(numElements, tree.getTreeTrashNode().getNodeCount());
             tree.close(false, close);

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathPrune.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathPrune.java
@@ -68,7 +68,7 @@ public class PathPrune extends PathElement {
 
     /**
      * If true then terminate the pruning process when the job is shutting down.
-     * Default is false. Note that specifying a prune in the "post" section
+     * Default is false. Note that specifying a prune in the "post" section and
      * setting preempt to true can prevent job pruning from happening if the
      * job always terminates when its maximum runtime is reached.
      * Consider specifying a prune in the "pre" section and setting preempt to true.

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathPrune.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathPrune.java
@@ -66,6 +66,15 @@ public class PathPrune extends PathElement {
      */
     @FieldConfig private int relativeDown = 0;
 
+    /**
+     * If true then terminate the pruning process when the job is shutting down.
+     * Default is false. Note that specifying a prune in the "post" section
+     * setting preempt to true can prevent job pruning from happening if the
+     * job always terminates when its maximum runtime is reached.
+     * Consider specifying a prune in the "pre" section and setting preempt to true.
+     */
+    @FieldConfig private boolean preempt = false;
+
     @Nullable private final DateTimeFormatter nameFormat;
 
     public PathPrune(@Nullable @JsonProperty("nameFormat") String nameFormatString) {
@@ -82,44 +91,50 @@ public class PathPrune extends PathElement {
     public TreeNodeList getNextNodeList(final TreeMapState state) {
         long now = JitterClock.globalTime();
         DataTreeNode root = state.current();
-
-        findAndPruneChildren(root, now, relativeDown);
+        findAndPruneChildren(state, root, now, relativeDown);
         return TreeMapState.empty();
     }
 
-    public void findAndPruneChildren(final DataTreeNode root, long now, int depth) {
+    public void findAndPruneChildren(final TreeMapState state, final DataTreeNode root, long now, int depth) {
         if (depth == 0) {
-            pruneChildren(root, now);
+            pruneChildren(state, root, now);
         } else {
             ClosableIterator<DataTreeNode> keyNodeItr = root.getIterator();
-            while (keyNodeItr.hasNext()) {
-                findAndPruneChildren(keyNodeItr.next(), now, depth - 1);
+            try {
+                while (keyNodeItr.hasNext()) {
+                    findAndPruneChildren(state, keyNodeItr.next(), now, depth - 1);
+                }
+            } finally {
+                keyNodeItr.close();
             }
-            keyNodeItr.close();
         }
     }
 
-    public void pruneChildren(final DataTreeNode root, long now) {
+    public void pruneChildren(final TreeMapState state, final DataTreeNode root, long now) {
         ClosableIterator<DataTreeNode> keyNodeItr = root.getIterator();
         int deleted = 0;
         int kept = 0;
         int total = 0;
-        while (keyNodeItr.hasNext()) {
-            DataTreeNode treeNode = keyNodeItr.next();
-            long nodeTime = getNodeTime(treeNode);
-            if ((nodeTime > 0) && ((now - nodeTime) > ttl)) {
-                root.deleteNode(treeNode.getName());
-                deleted++;
-            } else {
-                kept++;
+        try {
+            while (keyNodeItr.hasNext() && !(preempt && state.processorClosing())) {
+                DataTreeNode treeNode = keyNodeItr.next();
+                long nodeTime = getNodeTime(treeNode);
+                if ((nodeTime > 0) && ((now - nodeTime) > ttl)) {
+                    root.deleteNode(treeNode.getName());
+                    deleted++;
+                } else {
+                    kept++;
+                }
+                total++;
+                if ((total % 100000) == 0) {
+                    logger.info("Iterating through children of {}, deleted: {} kept: {}", root.getName(), deleted,
+                                kept);
+                }
             }
-            total++;
-            if ((total % 100000) == 0) {
-                logger.info("Iterating through children of {}, deleted: {} kept: {}", root.getName(), deleted, kept);
-            }
+        } finally {
+            logger.info("Iterated through children of {}, deleted: {} kept: {}", root.getName(), deleted, kept);
+            keyNodeItr.close();
         }
-        logger.info("Iterated through children of {}, deleted: {} kept: {}", root.getName(), deleted, kept);
-        keyNodeItr.close();
     }
 
     @VisibleForTesting long getNodeTime(DataTreeNode treeNode) {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapState.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapState.java
@@ -21,7 +21,6 @@ import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleFactory;
 import com.addthis.bundle.core.BundleFormat;
 import com.addthis.bundle.core.BundleFormatted;
-import com.addthis.hydra.common.util.CloseTask;
 import com.addthis.hydra.data.tree.DataTreeNode;
 import com.addthis.hydra.data.tree.DataTreeNodeInitializer;
 import com.addthis.hydra.data.tree.DataTreeNodeUpdater;

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapState.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapState.java
@@ -21,6 +21,7 @@ import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleFactory;
 import com.addthis.bundle.core.BundleFormat;
 import com.addthis.bundle.core.BundleFormatted;
+import com.addthis.hydra.common.util.CloseTask;
 import com.addthis.hydra.data.tree.DataTreeNode;
 import com.addthis.hydra.data.tree.DataTreeNodeInitializer;
 import com.addthis.hydra.data.tree.DataTreeNodeUpdater;
@@ -68,7 +69,6 @@ public final class TreeMapState implements DataTreeNodeUpdater, DataTreeNodeInit
         this.thread = Thread.currentThread();
         this.profiling = processor != null ? processor.isProfiling() : false;
         push(rootNode);
-        process();
     }
 
     private final LinkedList<DataTreeNode> leases = debuglist ? new DebugList() : new LinkedList<DataTreeNode>();
@@ -196,9 +196,6 @@ public final class TreeMapState implements DataTreeNodeUpdater, DataTreeNodeInit
         }
     }
 
-    /**
-     * called exclusively from Hydra.processRule()
-     */
     public void process() {
         try {
             TreeNodeList list = processPath(path, 0);
@@ -309,4 +306,6 @@ public final class TreeMapState implements DataTreeNodeUpdater, DataTreeNodeInit
     public BundleFormat getFormat() {
         return processor.getFormat();
     }
+
+    public boolean processorClosing() { return processor.isClosing(); }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
@@ -43,7 +43,6 @@ import com.addthis.bundle.core.kvp.KVBundle;
 import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.codec.codables.Codable;
-import com.addthis.hydra.common.util.CloseTask;
 import com.addthis.hydra.data.query.engine.QueryEngine;
 import com.addthis.hydra.data.query.source.LiveMeshyServer;
 import com.addthis.hydra.data.query.source.LiveQueryReference;

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
@@ -510,7 +510,7 @@ public final class TreeMapper extends DataOutputTypeList implements Codable, Clo
             }
             if (outputs != null) {
                 for (PathOutput output : outputs) {
-                    log.warn("output: {}", output);
+                    log.info("output: {}", output);
                     output.exec(tree);
                 }
             }
@@ -562,10 +562,10 @@ public final class TreeMapper extends DataOutputTypeList implements Codable, Clo
             perform = true;
         }
         if (perform) {
-            log.warn("{}-chain: {}", message, op);
+            log.info("{}-chain: {}", message, op);
             processBundle(new KVBundle(), op);
         } else {
-            log.warn("skipping {}-chain: {}. Sample rate is {} out of {}", message, op, sample, rate);
+            log.info("skipping {}-chain: {}. Sample rate is {} out of {}", message, op, sample, rate);
         }
         return perform;
     }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
@@ -13,7 +13,6 @@
  */
 package com.addthis.hydra.task.output.tree;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 
@@ -97,7 +96,7 @@ import org.slf4j.LoggerFactory;
  * @user-reference
  * @hydra-name tree
  */
-public final class TreeMapper extends DataOutputTypeList implements Codable, Closeable {
+public final class TreeMapper extends DataOutputTypeList implements Codable {
 
     private static final Logger log = LoggerFactory.getLogger(TreeMapper.class);
     private static final SimpleDateFormat date = new SimpleDateFormat("yyMMdd-HHmmss");
@@ -209,7 +208,7 @@ public final class TreeMapper extends DataOutputTypeList implements Codable, Clo
     private final IndexHash<PathElement[]>           pathIndex = new IndexHash();
 
     /**
-     * If true then process shutdown has begun.
+     * If true then jvm shutdown process has begun.
      */
     private final AtomicBoolean closing = new AtomicBoolean(false);
 
@@ -285,7 +284,7 @@ public final class TreeMapper extends DataOutputTypeList implements Codable, Clo
     @Override
     public void open() {
         try {
-            Runtime.getRuntime().addShutdownHook(new Thread(new CloseTask(this), "TreeMapper shutdown hook"));
+            Runtime.getRuntime().addShutdownHook(new Thread(this::jvmShutDown, "TreeMapper shutdown hook"));
 
             mapstats = new TreeMapperStats();
             resolve();
@@ -317,8 +316,7 @@ public final class TreeMapper extends DataOutputTypeList implements Codable, Clo
         }
     }
 
-    @Override
-    public void close() throws IOException {
+    private void jvmShutDown() {
         closing.set(true);
     }
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
@@ -560,7 +560,7 @@ public final class TreeMapper extends DataOutputTypeList implements Codable {
         int sample = 0;
         if (rate > 1) {
             File sampleFile = new File(filename);
-            if (Files.isFileReadable(filename)) {
+            if (sampleFile.exists() && sampleFile.isFile() && sampleFile.length() > 0) {
                 try {
                     sample = Integer.parseInt(Bytes.toString(Files.read(sampleFile)));
                     sample = (sample + 1) % rate;

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
@@ -306,6 +306,8 @@ public final class TreeMapper extends DataOutputTypeList implements Codable {
 
             startTime = System.currentTimeMillis();
 
+            tree.foregroundNodeDeletion(closing::get);
+
             if (pre != null) {
                 sampleOperation(pre, preRate, "pre.sample", "pre");
             }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
@@ -542,6 +542,19 @@ public final class TreeMapper extends DataOutputTypeList implements Codable {
         }
     }
 
+    /**
+     * Conditionally perform the array of path element operations. If {@code rate} is
+     * greater than 1 then test the contents of {@code filename} to determine whether
+     * to run the path element operations. Supply an empty bundle as input to the path
+     * operations.
+     *
+     * @param op         array of path operations that may be run
+     * @param rate       if greater than 1 then test the sample file
+     * @param filename   name of the sample file
+     * @param message    output prefix for logging
+     * @return           true iff path elements were executed
+     * @throws IOException
+     */
     private boolean sampleOperation(PathElement[] op, int rate, String filename, String message) throws IOException {
         boolean perform;
         int sample = 0;

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
@@ -283,7 +283,7 @@ public final class TreeMapper extends DataOutputTypeList implements Codable {
     @Override
     public void open() {
         try {
-            Runtime.getRuntime().addShutdownHook(new Thread(this::jvmShutDown, "TreeMapper shutdown hook"));
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> closing.set(true), "TreeMapper shutdown hook"));
 
             mapstats = new TreeMapperStats();
             resolve();
@@ -315,10 +315,6 @@ public final class TreeMapper extends DataOutputTypeList implements Codable {
         } catch (Exception ex) {
             Throwables.propagate(ex);
         }
-    }
-
-    private void jvmShutDown() {
-        closing.set(true);
     }
 
     private void connectToMesh(File root, String jobId, int taskId, QueryEngine engine) throws IOException {

--- a/hydra-task/src/test/java/com/addthis/hydra/task/output/tree/PathPruneTest.java
+++ b/hydra-task/src/test/java/com/addthis/hydra/task/output/tree/PathPruneTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 
 import com.addthis.basis.util.ClosableIterator;
 
+import com.addthis.bundle.core.list.ListBundle;
 import com.addthis.codec.config.Configs;
 import com.addthis.hydra.data.tree.DataTreeNode;
 
@@ -48,19 +49,21 @@ public class PathPruneTest {
 
     @Test
     public void deleteFromName() throws IOException {
+        TreeMapState state = new TreeMapState(new ListBundle());
         DataTreeNode parent = mockParent();
         PathPrune pathPrune = Configs.decodeObject(PathPrune.class, "ttl = 2 days, nameFormat = YYMMDD");
         long now = DateTimeFormat.forPattern("YYMMDD").parseMillis("140105");
-        pathPrune.pruneChildren(parent, now);
+        pathPrune.pruneChildren(state, parent, now);
         verify(parent).deleteNode("140101");
     }
 
     @Test
     public void keepFromName() throws IOException {
+        TreeMapState state = new TreeMapState(new ListBundle());
         DataTreeNode parent = mockParent();
         PathPrune pathPrune = Configs.decodeObject(PathPrune.class, "ttl = 20 days, nameFormat = YYMMDD");
         long now = DateTimeFormat.forPattern("YYMMDD").parseMillis("140105");
-        pathPrune.pruneChildren(parent, now);
+        pathPrune.pruneChildren(state, parent, now);
         verify(parent, never()).deleteNode("140101");
     }
 


### PR DESCRIPTION
Added 'preempt' boolean parameter to PathPrune. Allows preemption to be terminated when process is shutting down. Moved background node deletion in the ConcurrentTree from currently at the end of a job as a process that is not preempted to the new behavior of the beginning of a job as a process that is preempted when the JVM exits. 

Changes included:
    
- Moved the invocation of process() out of the TreeMapState constructor. This is also not necessary for the new feature it has just bugged me a lot.
    
- Added atomic boolean field 'closing' to TreeMapper class. Can be tested by other classes to determine if JVM is shutting down.
    
- Added boolean field 'preempt' to PathPrune with default value of false. Use 'preempt' in combination with TreeMapper#closing to determine if preemption is activated.
