### PR TITLE
remove [BV]Filter.open and make into interfaces

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/query/op/OpFilter.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/query/op/OpFilter.java
@@ -23,8 +23,9 @@ import com.addthis.bundle.core.Bundle;
 import com.addthis.hydra.data.filter.bundle.BundleFilter;
 import com.addthis.hydra.data.query.AbstractRowOp;
 
-import static com.addthis.codec.config.Configs.decodeObject;
 import io.netty.channel.ChannelProgressivePromise;
+
+import static com.addthis.codec.config.Configs.decodeObject;
 
 public class OpFilter extends AbstractRowOp {
 
@@ -34,7 +35,6 @@ public class OpFilter extends AbstractRowOp {
         super(queryPromise);
         try {
             filter = decodeObject(BundleFilter.class, args);
-            filter.open();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataCopy.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataCopy.java
@@ -94,11 +94,6 @@ public final class DataCopy extends TreeNodeData<DataCopy.Config> {
             for (Entry<String, String> s : conf.key.entrySet()) {
                 keyAccess.put(s.getKey(), p.getFormat().getField(s.getValue()));
             }
-            if (conf.op != null) {
-                for (ValueFilter filter : conf.op.values()) {
-                    filter.open();
-                }
-            }
         }
         // copy values from pipeline
         for (Entry<String, BundleField> s : keyAccess.entrySet()) {

--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataKeyTop.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataKeyTop.java
@@ -160,9 +160,6 @@ public class DataKeyTop extends TreeNodeData<DataKeyTop.Config> implements Codab
         if (keyAccess == null) {
             keyAccess = conf.key;
             filter = conf.filter;
-            if (filter != null) {
-                filter.open();
-            }
         }
         ValueObject val = keyAccess.getValue(state.getBundle());
         if (val != null) {

--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataPercentileDistribution.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/prop/DataPercentileDistribution.java
@@ -113,9 +113,6 @@ public class DataPercentileDistribution extends TreeNodeData<DataPercentileDistr
         if (keyAccess == null) {
             keyAccess = AutoField.newAutoField(conf.key);
             filter = conf.filter;
-            if (filter != null) {
-                filter.open();
-            }
         }
         ValueObject val = keyAccess.getValue(state.getBundle());
         if (val != null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/AbstractBundleFilterHttp.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/AbstractBundleFilterHttp.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.data.filter.bundle;
+
+import com.addthis.bundle.core.Bundle;
+import com.addthis.bundle.util.AutoField;
+import com.addthis.codec.annotations.FieldConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractBundleFilterHttp implements BundleFilter {
+    private static final Logger log = LoggerFactory.getLogger(AbstractBundleFilterHttp.class);
+
+    @FieldConfig(codable = true) protected CacheConfig cache;
+    @FieldConfig(codable = true) protected HttpConfig http;
+    @FieldConfig(codable = true) protected String defaultValue;
+    @FieldConfig(codable = true) protected boolean trace;
+    @FieldConfig(codable = true) protected BundleFilterTemplate url;
+    @FieldConfig(codable = true) protected AutoField set;
+
+    public static class CacheConfig {
+
+        @FieldConfig(codable = true)
+        public int size = 1000;
+        @FieldConfig(codable = true)
+        public long   age;
+        @FieldConfig(codable = true)
+        public String dir;
+    }
+
+    public static class HttpConfig {
+
+        @FieldConfig(codable = true)
+        public int  timeout      = 60000;
+        @FieldConfig(codable = true)
+        public int  retries      = 1;
+        @FieldConfig(codable = true)
+        public long retryTimeout = 1000;
+    }
+
+    public static final class ValidationBundleFilterHttp extends AbstractBundleFilterHttp {
+        @Override public boolean filter(Bundle row) {
+            throw new UnsupportedOperationException("This class is only intended for use in construction validation.");
+        }
+    }
+}

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilter.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilter.java
@@ -13,14 +13,12 @@
  */
 package com.addthis.hydra.data.filter.bundle;
 
+import java.util.function.Predicate;
+
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleField;
 import com.addthis.bundle.core.BundleFormat;
 import com.addthis.codec.annotations.Pluggable;
-import com.addthis.codec.codables.Codable;
-import com.addthis.codec.codables.SuperCodable;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
  * A bundle filter applies a transformation on a bundle and returns
@@ -29,15 +27,16 @@ import com.fasterxml.jackson.annotation.JsonCreator;
  * @user-reference
  * @hydra-category
  */
+@FunctionalInterface
 @Pluggable("bundle-filter")
-public abstract class BundleFilter implements Codable {
+public interface BundleFilter extends Predicate<Bundle> {
 
     /**
      * @param bundle      row/line/packet bundle
      * @param bindTargets use the same object or re-binding will occur
      * @return bound field wrappers
      */
-    protected final BundleField[] getBindings(final Bundle bundle, final String[] bindTargets) {
+    static BundleField[] getBindings(final Bundle bundle, final String[] bindTargets) {
         BundleField[] boundFields = null;
         if (bindTargets != null) {
             BundleFormat format = bundle.getFormat();
@@ -52,28 +51,10 @@ public abstract class BundleFilter implements Codable {
         return boundFields;
     }
 
-    /**
-     * The recommended pattern for initialization of BundleFilters is to
-     * use {@link JsonCreator} style constructors. See {@link BundleFilterNum}
-     * for an example of this pattern. This construction allows one to mark any
-     * appropriate fields as final fields which is a recommended best practice.
-     *
-     * BundleFilters may be instantiated and then never used again. For example
-     * this happens when we validate a job configuration in the user interface
-     * when a job is saved. Any stateful or expensive initialization, such as
-     * contacting a resource on the network or writing to a disk, should happen
-     * in this open method. Do not use {@link SuperCodable} for initialization
-     * of BundleFilters that is deprecated in favor of the approach described here.
-     *
-     * Any application using a BundleFilters must explicitly invoke the open
-     * method exactly once after the object has been initialized and before
-     * it is used. The best practice is to call the open method even if you
-     * know it performs no operation, as a future-proof for any changes to
-     * your application.
-     */
-    public abstract void open();
+    @Override default boolean test(Bundle row) {
+        return filter(row);
+    }
 
     /* returns true if chain should continue, false to break */
-    public abstract boolean filter(Bundle row);
-
+    abstract boolean filter(Bundle row);
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterAppend.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterAppend.java
@@ -52,7 +52,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * @user-reference
  * @hydra-name append
  */
-public class BundleFilterAppend extends BundleFilter {
+public class BundleFilterAppend implements BundleFilter {
 
     @JsonIgnore
     public BundleFilterAppend setValues(ArrayList<String> values) {
@@ -131,13 +131,6 @@ public class BundleFilterAppend extends BundleFilter {
      */
     @FieldConfig(codable = true)
     private int size = 5;
-
-    @Override
-    public void open() {
-        if (filter != null) {
-            filter.open();
-        }
-    }
 
     private boolean contains(ValueArray arr, ValueObject obj) {
         for (int i = 0; i < arr.size(); i++) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterChain.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterChain.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * @user-reference
  * @hydra-name chain
  */
-public class BundleFilterChain extends BundleFilter {
+public class BundleFilterChain implements BundleFilter {
 
     private static final Logger log = LoggerFactory.getLogger(BundleFilterChain.class);
 
@@ -66,13 +66,6 @@ public class BundleFilterChain extends BundleFilter {
     private long debugMaxBundles = 100;
 
     private final AtomicLong bundleCounter = new AtomicLong();
-
-    @Override
-    public void open() {
-        for (BundleFilter f : filter) {
-            f.open();
-        }
-    }
 
     @Override
     public boolean filter(Bundle row) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterClear.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterClear.java
@@ -38,7 +38,7 @@ import com.addthis.hydra.data.filter.value.ValueFilter;
  * @user-reference
  * @hydra-name clear
  */
-public class BundleFilterClear extends BundleFilter {
+public class BundleFilterClear implements BundleFilter {
 
     /** The target field for clearing the value. This field is required. */
     @FieldConfig(required = true) private AutoField field;
@@ -54,13 +54,6 @@ public class BundleFilterClear extends BundleFilter {
 
     /** If true then remove the field rather than set it to null. Default is false. */
     @FieldConfig private boolean removes = false;
-
-    @Override
-    public void open() {
-        if (filter != null) {
-            filter.open();
-        }
-    }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterConcat.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterConcat.java
@@ -35,7 +35,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name concat
  */
-public class BundleFilterConcat extends BundleFilter {
+public class BundleFilterConcat implements BundleFilter {
 
     /** An array of fields to concatenate. This field is required. */
     @FieldConfig(required = true) private AutoField[] in;
@@ -45,9 +45,6 @@ public class BundleFilterConcat extends BundleFilter {
 
     /** An optional separator to place in between elements of the output string. */
     @FieldConfig private String join;
-
-    @Override
-    public void open() { }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterCondition.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterCondition.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @user-reference
  * @hydra-name condition
  */
-public class BundleFilterCondition extends BundleFilter {
+public class BundleFilterCondition implements BundleFilter {
 
     /** The conditional bundle filter. This field is required. */
     @NotNull
@@ -70,17 +70,6 @@ public class BundleFilterCondition extends BundleFilter {
         this.ifCondition = ifCondition;
         this.ifDo = ifDo;
         this.elseDo = elseDo;
-    }
-
-    @Override
-    public void open() {
-        ifCondition.open();
-        if (ifDo != null) {
-            ifDo.open();
-        }
-        if (elseDo != null) {
-            elseDo.open();
-        }
     }
 
     @Override

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterContains.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterContains.java
@@ -14,11 +14,9 @@
 package com.addthis.hydra.data.filter.bundle;
 
 import com.addthis.bundle.core.Bundle;
-import com.addthis.bundle.core.BundleField;
 import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.util.ValueUtil;
 import com.addthis.bundle.value.ValueObject;
-import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.hydra.data.filter.value.ValueFilterContains;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -44,7 +42,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @user-reference
  * @hydra-name contains
  */
-public class BundleFilterContains extends BundleFilter {
+public class BundleFilterContains implements BundleFilter {
 
     /**
      * The input field to test. This field is required.
@@ -82,13 +80,6 @@ public class BundleFilterContains extends BundleFilter {
             filter = new ValueFilterContains(value, null, false, false);
         } else {
             filter = null;
-        }
-    }
-
-    @Override
-    public void open() {
-        if (filter != null) {
-            filter.open();
         }
     }
 

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterDebugPrint.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterDebugPrint.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * @user-reference
  * @hydra-name debug
  */
-public class BundleFilterDebugPrint extends BundleFilter {
+public class BundleFilterDebugPrint implements BundleFilter {
 
     private static final Logger log = LoggerFactory.getLogger(BundleFilterDebugPrint.class);
 
@@ -81,9 +81,6 @@ public class BundleFilterDebugPrint extends BundleFilter {
 
     // Should be used solely for unit testing.
     private boolean enableCacheOutput = false;
-
-    @Override
-    public void open() { }
 
     BundleFilterDebugPrint enableCacheOutput() {
         this.enableCacheOutput = true;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterDefaults.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterDefaults.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @user-reference
  * @hydra-name defaults
  */
-public class BundleFilterDefaults extends BundleFilter {
+public class BundleFilterDefaults implements BundleFilter {
 
     /**
      * A mapping of bundle fields to default bundle values. This field is required.
@@ -58,9 +58,6 @@ public class BundleFilterDefaults extends BundleFilter {
         }
         this.defaults = map;
     }
-
-    @Override
-    public void open() { }
 
     @Override
     public boolean filter(Bundle row) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterEquals.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterEquals.java
@@ -39,7 +39,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name equals
  */
-public class BundleFilterEquals extends BundleFilter {
+public class BundleFilterEquals implements BundleFilter {
 
     /**
      * the left hand field value
@@ -58,9 +58,6 @@ public class BundleFilterEquals extends BundleFilter {
      */
     @FieldConfig(codable = true)
     private boolean not;
-
-    @Override
-    public void open() { }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterError.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterError.java
@@ -14,7 +14,6 @@
 package com.addthis.hydra.data.filter.bundle;
 
 import com.addthis.bundle.core.Bundle;
-import com.addthis.hydra.data.filter.value.ValueFilter;
 
 import com.google.common.base.Throwables;
 
@@ -25,7 +24,7 @@ import static com.fasterxml.jackson.annotation.JsonTypeInfo.As.EXTERNAL_PROPERTY
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.MINIMAL_CLASS;
 
 /**
- * This {@link ValueFilter BundleFilter} <span class="hydra-summary">throws an exception</span>.
+ * This {@link BundleFilter} <span class="hydra-summary">throws an exception</span>.
  * <p>This filter can be used either by developers when testing out the error handling
  * of the system or it can be used by users when they want to explicitly trigger the
  * error of a job.
@@ -38,7 +37,7 @@ import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.MINIMAL_CLASS;
  * @user-reference
  * @hydra-name error
  */
-public class BundleFilterError extends BundleFilter {
+public class BundleFilterError implements BundleFilter {
 
     @JsonTypeInfo(use = MINIMAL_CLASS, include = EXTERNAL_PROPERTY, property = "type",
             defaultImpl = RuntimeException.class)
@@ -49,5 +48,4 @@ public class BundleFilterError extends BundleFilter {
         throw Throwables.propagate(message);
     }
 
-    @Override public void open() {}
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterEvalJava.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterEvalJava.java
@@ -182,7 +182,6 @@ public class BundleFilterEvalJava implements BundleFilter, SuperCodable {
         classDecl.append("{\n");
         createConstructor(classDecl, className);
         createFieldsVariable(classDecl);
-        createInitializer(classDecl);
         createFilterMethod(classDecl);
         classDecl.append("}\n");
         classDeclString = classDecl.toString();
@@ -236,10 +235,6 @@ public class BundleFilterEvalJava implements BundleFilter, SuperCodable {
             }
             classDecl.append("};\n");
         }
-    }
-
-    private void createInitializer(StringBuffer classDecl) {
-        classDecl.append("public void open() {}\n");
     }
 
     private IllegalStateException handleCompilationError(String classDeclString, JavaSimpleCompiler compiler) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterEvalJava.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterEvalJava.java
@@ -72,6 +72,8 @@ public class BundleFilterEvalJava implements BundleFilter, SuperCodable {
 
     private static final Logger log = LoggerFactory.getLogger(BundleFilterEvalJava.class);
 
+    private BundleFilterEvalJava() {}
+
     /**
      * Names of the bundle fields. These
      * fields will be available in the filter

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterEvalJava.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterEvalJava.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.annotations.FieldConfig;
+import com.addthis.codec.codables.SuperCodable;
 import com.addthis.hydra.data.compiler.JavaSimpleCompiler;
 import com.addthis.hydra.data.filter.eval.InputType;
 
@@ -67,7 +68,7 @@ import org.slf4j.LoggerFactory;
  * @user-reference
  * @hydra-name eval-java
  */
-public class BundleFilterEvalJava extends BundleFilter {
+public class BundleFilterEvalJava implements BundleFilter, SuperCodable {
 
     private static final Logger log = LoggerFactory.getLogger(BundleFilterEvalJava.class);
 
@@ -214,7 +215,6 @@ public class BundleFilterEvalJava extends BundleFilter {
                 log.warn("\n" + classDeclString);
                 throw new IllegalStateException(msg);
             }
-            filter.open();
             return filter;
         } finally {
             compiler.cleanupFiles(className);
@@ -362,9 +362,7 @@ public class BundleFilterEvalJava extends BundleFilter {
         this.types = types;
     }
 
-
-    @Override
-    public void open() {
+    @Override public void postDecode() {
         typeBundle = false;
         for (int i = 0; i < types.length; i++) {
             if (types[i].equals(InputType.BUNDLE_RAW)) {
@@ -385,4 +383,6 @@ public class BundleFilterEvalJava extends BundleFilter {
         }
         constructedFilter = createConstructedFilter();
     }
+
+    @Override public void preEncode() {}
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterField.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterField.java
@@ -37,7 +37,7 @@ import com.addthis.hydra.data.filter.value.ValueFilter;
  * @user-reference
  * @hydra-name field
  */
-public class BundleFilterField extends BundleFilter {
+public class BundleFilterField implements BundleFilter {
 
     public BundleFilterField setNullFail(boolean nullFail) {
         this.nullFail = nullFail;
@@ -61,12 +61,6 @@ public class BundleFilterField extends BundleFilter {
 
     /** The value to return when nullFail is true and the value filter output is null. Default is false. */
     @FieldConfig private boolean not;
-
-    @Override public void open() {
-        if (filter != null) {
-            filter.open();
-        }
-    }
 
     @Override
     public boolean filter(Bundle row) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterFirstValue.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterFirstValue.java
@@ -41,7 +41,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name first
  */
-public class BundleFilterFirstValue extends BundleFilter {
+public class BundleFilterFirstValue implements BundleFilter {
 
     /**
      * An array of bundle field names to search. This field is required.
@@ -61,9 +61,6 @@ public class BundleFilterFirstValue extends BundleFilter {
      */
     @FieldConfig(codable = true)
     private AutoField which;
-
-    @Override
-    public void open() {}
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterHttp.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterHttp.java
@@ -31,6 +31,7 @@ import com.addthis.bundle.value.ValueFactory;
 import com.addthis.codec.Codec;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.codec.codables.Codable;
+import com.addthis.codec.codables.SuperCodable;
 import com.addthis.codec.json.CodecJSON;
 import com.addthis.hydra.common.hash.MD5HashFunction;
 import com.addthis.hydra.data.filter.value.ValueFilterHttpGet;
@@ -48,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * @user-reference
  * @hydra-name http
  */
-public class BundleFilterHttp extends BundleFilter {
+public class BundleFilterHttp extends AbstractBundleFilterHttp implements SuperCodable {
 
     public static BundleFilterHttp create(BundleFilterTemplate url, String set) {
         BundleFilterHttp bfh = new BundleFilterHttp();
@@ -60,62 +61,11 @@ public class BundleFilterHttp extends BundleFilter {
     private static final Logger log   = LoggerFactory.getLogger(BundleFilterHttp.class);
     private static final Codec  codec = CodecJSON.INSTANCE;
 
-    @FieldConfig(codable = true)
-    private CacheConfig          cache;
-    @FieldConfig(codable = true)
-    private HttpConfig           http;
-    @FieldConfig(codable = true)
-    private String               defaultValue;
-    @FieldConfig(codable = true)
-    private boolean              trace;
-    @FieldConfig(codable = true)
-    private BundleFilterTemplate url;
-    @FieldConfig(codable = true)
-    private AutoField            set;
-
-    private File                        persistTo;
-
+    private File persistTo;
     private HotMap<String, CacheObject> ocache;
 
-    public static class CacheConfig {
 
-        @FieldConfig(codable = true)
-        private int size = 1000;
-        @FieldConfig(codable = true)
-        private long   age;
-        @FieldConfig(codable = true)
-        private String dir;
-    }
-
-    public static class HttpConfig {
-
-        @FieldConfig(codable = true)
-        private int  timeout      = 60000;
-        @FieldConfig(codable = true)
-        private int  retries      = 1;
-        @FieldConfig(codable = true)
-        private long retryTimeout = 1000;
-    }
-
-    public static class CacheObject implements Codable, Comparable<CacheObject> {
-
-        @FieldConfig(codable = true)
-        private long   time;
-        @FieldConfig(codable = true)
-        private String key;
-        @FieldConfig(codable = true)
-        private String data;
-
-        private String hash;
-
-        @Override
-        public int compareTo(CacheObject o) {
-            return (int) (time - o.time);
-        }
-    }
-
-    @Override
-    public void open() {
+    @Override public void postDecode() {
         if (cache == null) {
             cache = new CacheConfig();
         }
@@ -151,8 +101,24 @@ public class BundleFilterHttp extends BundleFilter {
                 ocache.put(cached.key, cached);
             }
         }
-        if (url != null) {
-            url.open();
+    }
+
+    @Override public void preEncode() {}
+
+    public static class CacheObject implements Codable, Comparable<CacheObject> {
+
+        @FieldConfig(codable = true)
+        private long   time;
+        @FieldConfig(codable = true)
+        private String key;
+        @FieldConfig(codable = true)
+        private String data;
+
+        private String hash;
+
+        @Override
+        public int compareTo(CacheObject o) {
+            return (int) (time - o.time);
         }
     }
 

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterHttp.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterHttp.java
@@ -55,6 +55,7 @@ public class BundleFilterHttp extends AbstractBundleFilterHttp implements SuperC
         BundleFilterHttp bfh = new BundleFilterHttp();
         bfh.url = url;
         bfh.set = AutoField.newAutoField(set);
+        bfh.postDecode();
         return bfh;
     }
 
@@ -64,6 +65,7 @@ public class BundleFilterHttp extends AbstractBundleFilterHttp implements SuperC
     private File persistTo;
     private HotMap<String, CacheObject> ocache;
 
+    private BundleFilterHttp() {}
 
     @Override public void postDecode() {
         if (cache == null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterJSON.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterJSON.java
@@ -21,7 +21,6 @@ import com.addthis.basis.collect.HotMap;
 import com.addthis.basis.util.Strings;
 
 import com.addthis.bundle.core.Bundle;
-import com.addthis.bundle.core.BundleField;
 import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueObject;
@@ -40,7 +39,7 @@ import com.addthis.maljson.JSONObject;
  * @user-reference
  * @hydra-name json
  */
-public class BundleFilterJSON extends BundleFilter {
+public class BundleFilterJSON implements BundleFilter {
 
     public static BundleFilterJSON create(String json, String set, BundleFilterTemplate query) {
         BundleFilterJSON bfj = new BundleFilterJSON();
@@ -63,11 +62,6 @@ public class BundleFilterJSON extends BundleFilter {
 
     private HotMap<String, Object> objCache = new HotMap<>(new ConcurrentHashMap());
     private HotMap<String, ArrayList<QueryToken>> tokCache = new HotMap<>(new ConcurrentHashMap());
-
-    @Override
-    public void open() {
-        query.open();
-    }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterLimit.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterLimit.java
@@ -31,17 +31,13 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name limit
  */
-public class BundleFilterLimit extends BundleFilter {
+public class BundleFilterLimit implements BundleFilter {
 
     /**
      * The number of rows to permit. This field is required.
      */
     @FieldConfig(codable = true, required = true)
     private int limit;
-
-    @Override
-    public void open() {
-    }
 
     @Override
     public boolean filter(Bundle row) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterMap.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterMap.java
@@ -15,6 +15,7 @@ package com.addthis.hydra.data.filter.bundle;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.annotations.FieldConfig;
+import com.addthis.codec.codables.SuperCodable;
 
 /**
  * This {@link BundleFilter BundleFilter} <span class="hydra-summary">executes a sequence of {@link BundleFilterField BundleFilterField} operations</span>.
@@ -38,7 +39,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name map
  */
-public class BundleFilterMap extends BundleFilter {
+public class BundleFilterMap implements BundleFilter, SuperCodable {
 
     /**
      * The sequence of field bundle filters to execute.
@@ -59,15 +60,15 @@ public class BundleFilterMap extends BundleFilter {
     @FieldConfig(codable = true)
     private Boolean nullFail;
 
-    @Override
-    public void open() {
+    @Override public void postDecode() {
         for (BundleFilterField f : fields) {
-            f.open();
             if (nullFail != null) {
                 f.setNullFail(nullFail);
             }
         }
     }
+
+    @Override public void preEncode() {}
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterMap.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterMap.java
@@ -60,6 +60,8 @@ public class BundleFilterMap implements BundleFilter, SuperCodable {
     @FieldConfig(codable = true)
     private Boolean nullFail;
 
+    private BundleFilterMap() {}
+
     @Override public void postDecode() {
         for (BundleFilterField f : fields) {
             if (nullFail != null) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterMapExtract.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterMapExtract.java
@@ -14,7 +14,6 @@
 package com.addthis.hydra.data.filter.bundle;
 
 import com.addthis.bundle.core.Bundle;
-import com.addthis.bundle.core.BundleField;
 import com.addthis.bundle.core.BundleFormat;
 import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.value.ValueMap;
@@ -22,6 +21,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.bundle.value.ValueTranslationException;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.codec.codables.Codable;
+import com.addthis.hydra.data.filter.value.AbstractValueFilter;
 import com.addthis.hydra.data.filter.value.ValueFilter;
 
 import org.slf4j.Logger;
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  * @user-reference
  * @hydra-name map-extract
  */
-public class BundleFilterMapExtract extends BundleFilter {
+public class BundleFilterMapExtract implements BundleFilter {
 
     private static final Logger log = LoggerFactory.getLogger(BundleFilterMapExtract.class);
 
@@ -71,17 +71,6 @@ public class BundleFilterMapExtract extends BundleFilter {
      */
     @FieldConfig(codable = true, required = true)
     private XMap[] map;
-
-    @Override
-    public void open() {
-        if (map != null) {
-            for (XMap mapping : map) {
-                if (mapping.filter != null) {
-                    mapping.filter.open();
-                }
-            }
-        }
-    }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterNot.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterNot.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @user-reference
  * @hydra-name not
  */
-public class BundleFilterNot extends BundleFilter {
+public class BundleFilterNot implements BundleFilter {
 
     /** The field to test. This field is required. */
     private final AutoField field;
@@ -37,9 +37,6 @@ public class BundleFilterNot extends BundleFilter {
     public BundleFilterNot(@JsonProperty("field") AutoField field) {
         this.field = field;
     }
-
-    @Override
-    public void open() { }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterNum.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterNum.java
@@ -317,7 +317,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @user-reference
  * @hydra-name num
  */
-public class BundleFilterNum extends BundleFilter {
+public class BundleFilterNum implements BundleFilter {
 
     /**
      * Sequence of commands to execute (comma-delimited)
@@ -338,9 +338,6 @@ public class BundleFilterNum extends BundleFilter {
         this.columns = columns;
         this.calculator = new BundleCalculator(define);
     }
-
-    @Override
-    public void open() {}
 
     protected Bundle makeAltBundle(Bundle bundle) {
         ListBundleFormat format = new ListBundleFormat();

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterRandomField.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterRandomField.java
@@ -41,7 +41,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @user-reference
  * @hydra-name random-field
  */
-public class BundleFilterRandomField extends BundleFilter {
+public class BundleFilterRandomField implements BundleFilter {
 
     /**
      * The possible input bundle fields from which one will be selected. This field is required.
@@ -58,9 +58,6 @@ public class BundleFilterRandomField extends BundleFilter {
         this.inFields = inFields;
         this.out = out;
     }
-
-    @Override
-    public void open() { }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterRecent1.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterRecent1.java
@@ -38,7 +38,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name recent1
  */
-public final class BundleFilterRecent1 extends BundleFilter {
+public final class BundleFilterRecent1 implements BundleFilter {
 
     @FieldConfig(codable = true, required = true)
     private AutoField       time;
@@ -61,9 +61,6 @@ public final class BundleFilterRecent1 extends BundleFilter {
 
     @SuppressWarnings("unchecked")
     private HotMap<String, Mark> cache = new HotMap<>(new HashMap());
-
-    @Override
-    public void open() { }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterRecent2.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterRecent2.java
@@ -41,7 +41,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name recent2
  */
-public final class BundleFilterRecent2 extends BundleFilter {
+public final class BundleFilterRecent2 implements BundleFilter {
 
     @FieldConfig(codable = true, required = true)
     private AutoField       time;
@@ -64,9 +64,6 @@ public final class BundleFilterRecent2 extends BundleFilter {
 
     @SuppressWarnings("unchecked")
     private HotMap<String, Mark> cache = new HotMap<>(new HashMap());
-
-    @Override
-    public void open() { }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterSleep.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterSleep.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * @user-reference
  * @hydra-name sleep
  */
-public class BundleFilterSleep extends BundleFilter {
+public class BundleFilterSleep implements BundleFilter {
 
     private final Logger log = LoggerFactory.getLogger(BundleFilterSleep.class);
 
@@ -36,10 +36,6 @@ public class BundleFilterSleep extends BundleFilter {
      */
     @FieldConfig(codable = true, required = true)
     private int duration;
-
-    @Override
-    public void open() {
-    }
 
     @Override
     public boolean filter(Bundle row) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTemplate.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTemplate.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.BundleField;
 import com.addthis.bundle.value.ValueFactory;
-import com.addthis.codec.annotations.FieldConfig;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -29,7 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * @user-reference
  */
-public class BundleFilterTemplate extends BundleFilter {
+public class BundleFilterTemplate implements BundleFilter {
 
     private static final Logger log = LoggerFactory.getLogger(BundleFilterTemplate.class);
 
@@ -65,12 +64,9 @@ public class BundleFilterTemplate extends BundleFilter {
     }
 
     @Override
-    public void open() { }
-
-    @Override
     public boolean filter(Bundle bundle) {
         try {
-            BundleField[] bound = getBindings(bundle, fieldSet);
+            BundleField[] bound = BundleFilter.getBindings(bundle, fieldSet);
             StringBuilder sb = new StringBuilder();
             for (Token token : tokenSet) {
                 sb.append(token.value(bundle, bound));
@@ -85,7 +81,7 @@ public class BundleFilterTemplate extends BundleFilter {
 
     public String template(Bundle bundle) {
         filter(bundle);
-        BundleField[] bound = getBindings(bundle, fieldSet);
+        BundleField[] bound = BundleFilter.getBindings(bundle, fieldSet);
         return bundle.getValue(bound[bound.length - 1]).toString();
     }
 

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTest.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTest.java
@@ -32,7 +32,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name test
  */
-public class BundleFilterTest extends BundleFilter {
+public class BundleFilterTest implements BundleFilter {
 
     /**
      * The bundle filter that is queried for a true or false return value. This field is required.
@@ -58,13 +58,6 @@ public class BundleFilterTest extends BundleFilter {
      */
     @FieldConfig(codable = true)
     private int loop = 1;
-
-    @Override
-    public void open() {
-        test.open();
-        onTrue.open();
-        onFalse.open();
-    }
 
     @Override
     public boolean filter(Bundle row) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTime.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTime.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * @user-reference
  * @hydra-name time
  */
-public class BundleFilterTime extends BundleFilter {
+public class BundleFilterTime implements BundleFilter {
 
     private final Logger log = LoggerFactory.getLogger(BundleFilterTime.class);
 
@@ -74,9 +74,6 @@ public class BundleFilterTime extends BundleFilter {
     public TimeField getOutput() {
         return dst;
     }
-
-    @Override
-    public void open() { }
 
     @Override
     public boolean filter(Bundle row) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTimeRange.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTimeRange.java
@@ -43,7 +43,7 @@ import org.joda.time.format.DateTimeFormatter;
  * @user-reference
  * @hydra-name time-range
  */
-public class BundleFilterTimeRange extends BundleFilter {
+public class BundleFilterTimeRange implements BundleFilter {
 
     private static final DateTimeFormatter ymd   = DateTimeFormat.forPattern("yyMMdd");
     private static final DateTimeFormatter ymdh  = DateTimeFormat.forPattern("yyMMddHH");
@@ -104,9 +104,6 @@ public class BundleFilterTimeRange extends BundleFilter {
             tafter = 0;
         }
     }
-
-    @Override
-    public void open() { }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTry.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterTry.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @user-reference
  * @hydra-name try
  */
-public class BundleFilterTry extends BundleFilter {
+public class BundleFilterTry implements BundleFilter {
 
     @JsonProperty("try")
     @FieldConfig(required = true)
@@ -37,14 +37,6 @@ public class BundleFilterTry extends BundleFilter {
     @JsonProperty("catch")
     @FieldConfig(required = true)
     BundleFilter catchDo;
-
-    @Override
-    public void open() {
-        tryDo.open();
-        if (catchDo != null) {
-            catchDo.open();
-        }
-    }
 
     @Override
     public boolean filter(Bundle row) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterURL.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterURL.java
@@ -52,7 +52,7 @@ import com.google.common.net.InternetDomainName;
  * @user-reference
  * @hydra-name url
  */
-public final class BundleFilterURL extends BundleFilter {
+public final class BundleFilterURL implements BundleFilter {
 
     private static final HotMap<String, String> iphost = new HotMap<>(new ConcurrentHashMap<String, String>());
     private static final int maxhostcache = Integer.parseInt(System.getProperty("packet.cachehost.max", "4000"));
@@ -233,9 +233,6 @@ public final class BundleFilterURL extends BundleFilter {
     }
 
     private static final Joiner DOT_JOINER = Joiner.on('.');
-
-    @Override
-    public void open() { }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterValue.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterValue.java
@@ -31,7 +31,7 @@ import com.addthis.hydra.data.filter.value.ValueFilter;
  * @user-reference
  * @hydra-name value
  */
-public class BundleFilterValue extends BundleFilter {
+public class BundleFilterValue implements BundleFilter {
 
     /**
      * The value to assign into a bundle field. This field is required.
@@ -56,13 +56,6 @@ public class BundleFilterValue extends BundleFilter {
      */
     @FieldConfig(codable = true)
     private boolean nullFail = true;
-
-    @Override
-    public void open() {
-        if (filter != null) {
-            filter.open();
-        }
-    }
 
     @Override
     public boolean filter(Bundle bundle) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/unary/BundleFilterUnary.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/unary/BundleFilterUnary.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class BundleFilterUnary extends BundleFilter {
+public class BundleFilterUnary implements BundleFilter {
 
     @Nonnull  private final UnaryOperation operation;
     @Nullable private final BundleFilter   filter;
@@ -33,12 +33,6 @@ public class BundleFilterUnary extends BundleFilter {
                                 @Nullable @JsonProperty("filter")   BundleFilter filter) {
         this.operation = checkNotNull(operation);
         this.filter = filter;
-    }
-
-    @Override public void open() {
-        if (filter != null) {
-            filter.open();
-        }
     }
 
     @Override public boolean filter(Bundle row) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/BundleFilterAlwaysValidates.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/BundleFilterAlwaysValidates.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.data.filter.closeablebundle;
+
+import com.addthis.bundle.core.Bundle;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BundleFilterAlwaysValidates implements CloseableBundleFilter {
+    private static final Logger log = LoggerFactory.getLogger(BundleFilterAlwaysValidates.class);
+
+    @Override public boolean filter(Bundle row) {
+        throw new UnsupportedOperationException("This class is only intended for use in construction validation.");
+    }
+
+    @Override public void close() {
+        throw new UnsupportedOperationException("This class is only intended for use in construction validation.");
+    }
+}

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilter.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilter.java
@@ -18,8 +18,8 @@ import com.addthis.codec.codables.Codable;
 import com.addthis.hydra.data.filter.bundle.BundleFilter;
 
 @Pluggable("closeable bundle filter")
-public abstract class CloseableBundleFilter extends BundleFilter implements Codable {
+public interface CloseableBundleFilter extends BundleFilter {
 
     /* Filters can implement this if they want to save their data somehow after a job finishes */
-    public abstract void close();
+    abstract void close();
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterChain.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterChain.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * execute a bundle filter chain.
  * optionally exit on a filter failure
  */
-public class CloseableBundleFilterChain extends CloseableBundleFilter {
+public class CloseableBundleFilterChain implements CloseableBundleFilter {
 
     private static final Logger log = LoggerFactory.getLogger(CloseableBundleFilterChain.class);
 
@@ -37,13 +37,6 @@ public class CloseableBundleFilterChain extends CloseableBundleFilter {
     private boolean failReturn = false;
     @FieldConfig(codable = true)
     private boolean debug;
-
-    @Override
-    public void open() {
-        for (CloseableBundleFilter f : filter) {
-            f.open();
-        }
-    }
 
     @Override
     public boolean filter(Bundle row) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterDelete.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterDelete.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.annotations.FieldConfig;
+import com.addthis.codec.codables.SuperCodable;
 
 import org.apache.commons.io.FileUtils;
 
@@ -25,21 +26,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class CloseableBundleFilterDelete extends CloseableBundleFilter {
+public class CloseableBundleFilterDelete implements SuperCodable, CloseableBundleFilter {
+    private static final Logger log = LoggerFactory.getLogger(CloseableBundleFilterDelete.class);
 
     @FieldConfig(codable = true, required = true)
     private String fileName;
     @FieldConfig(codable = true)
     private boolean pre = false;
 
-    private Logger log = LoggerFactory.getLogger(CloseableBundleFilterDelete.class);
-
-    @Override
-    public void open() {
+    @Override public void postDecode() {
         if (pre) {
             delete(fileName);
         }
     }
+
+    @Override public void preEncode() {}
 
     @Override
     public void close() {
@@ -67,4 +68,5 @@ public class CloseableBundleFilterDelete extends CloseableBundleFilter {
     public boolean filter(Bundle row) {
         return true;
     }
+
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterDelete.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterDelete.java
@@ -34,6 +34,8 @@ public class CloseableBundleFilterDelete implements SuperCodable, CloseableBundl
     @FieldConfig(codable = true)
     private boolean pre = false;
 
+    private CloseableBundleFilterDelete() {}
+
     @Override public void postDecode() {
         if (pre) {
             delete(fileName);

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterSet.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/closeablebundle/CloseableBundleFilterSet.java
@@ -14,13 +14,12 @@
 package com.addthis.hydra.data.filter.closeablebundle;
 
 import com.addthis.bundle.core.Bundle;
-import com.addthis.bundle.core.BundleField;
 import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.value.ValueFactory;
 import com.addthis.codec.annotations.FieldConfig;
 
 
-public class CloseableBundleFilterSet extends CloseableBundleFilter {
+public class CloseableBundleFilterSet implements CloseableBundleFilter {
 
     @FieldConfig(codable = true, required = true)
     private String value;
@@ -30,13 +29,6 @@ public class CloseableBundleFilterSet extends CloseableBundleFilter {
     private CloseableBundleFilter filter;
     @FieldConfig(codable = true)
     private boolean not;
-
-    @Override
-    public void open() {
-        if (filter != null) {
-            filter.open();
-        }
-    }
 
     @Override
     public void close() {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/AbstractMatchStringFilter.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/AbstractMatchStringFilter.java
@@ -78,19 +78,19 @@ abstract class AbstractMatchStringFilter extends StringFilter implements SuperCo
     private ArrayList<Pattern> pattern;
     private ArrayList<Pattern> findPattern;
 
-    public AbstractMatchStringFilter(HashSet<String> value,
-                                     String valueURL,
-                                     HashSet<String> match,
-                                     String matchURL,
-                                     HashSet<String> find,
-                                     String findURL,
-                                     String[] contains,
-                                     String containsURL,
-                                     boolean urlReturnsCSV,
-                                     boolean toLower,
-                                     int urlTimeout,
-                                     int urlRetries,
-                                     boolean not) {
+    AbstractMatchStringFilter(HashSet<String> value,
+                              String valueURL,
+                              HashSet<String> match,
+                              String matchURL,
+                              HashSet<String> find,
+                              String findURL,
+                              String[] contains,
+                              String containsURL,
+                              boolean urlReturnsCSV,
+                              boolean toLower,
+                              int urlTimeout,
+                              int urlRetries,
+                              boolean not) {
         this.value = value;
         this.valueURL = valueURL;
         this.match = match;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/AbstractMatchStringFilter.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/AbstractMatchStringFilter.java
@@ -4,9 +4,13 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.regex.Pattern;
 
+import com.addthis.bundle.value.ValueObject;
+import com.addthis.codec.codables.SuperCodable;
 import com.addthis.hydra.data.util.JSONFetcher;
 
-abstract class AbstractMatchStringFilter extends StringFilter {
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+abstract class AbstractMatchStringFilter extends StringFilter implements SuperCodable {
 
     /**
      * The input must match exactly to an element in this set.
@@ -160,8 +164,7 @@ abstract class AbstractMatchStringFilter extends StringFilter {
         return false;
     }
 
-    @Override
-    public void open() {
+    @Override public void postDecode() {
         if (valueURL != null) {
             if (urlReturnsCSV) {
                 value = JSONFetcher.staticLoadCSVSet(valueURL, urlTimeout, urlRetries, value);
@@ -207,6 +210,45 @@ abstract class AbstractMatchStringFilter extends StringFilter {
             }
 
             contains = tmp.toArray(new String[tmp.size()]);
+        }
+    }
+
+    @Override public void preEncode() {}
+
+    private static final class ValidationOnly extends AbstractMatchStringFilter {
+        public ValidationOnly(@JsonProperty("value") HashSet<String> value,
+                              @JsonProperty("valueURL") String valueURL,
+                              @JsonProperty("match") HashSet<String> match,
+                              @JsonProperty("matchURL") String matchURL,
+                              @JsonProperty("find") HashSet<String> find,
+                              @JsonProperty("findURL") String findURL,
+                              @JsonProperty("contains") String[] contains,
+                              @JsonProperty("containsURL") String containsURL,
+                              @JsonProperty("urlReturnsCSV") boolean urlReturnsCSV,
+                              @JsonProperty("toLower") boolean toLower,
+                              @JsonProperty("urlTimeout") int urlTimeout,
+                              @JsonProperty("urlRetries") int urlRetries) {
+            super(value,
+                  valueURL,
+                  match,
+                  matchURL,
+                  find,
+                  findURL,
+                  contains,
+                  containsURL,
+                  urlReturnsCSV,
+                  toLower,
+                  urlTimeout,
+                  urlRetries,
+                  false);
+        }
+
+        @Override public void postDecode() {
+            // intentionally do nothing
+        }
+
+        @Override public ValueObject filter(ValueObject value) {
+            throw new UnsupportedOperationException("This class is only intended for use in construction validation.");
         }
     }
 

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/AbstractValueFilter.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/AbstractValueFilter.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.data.filter.value;
+
+import javax.annotation.Nullable;
+
+import com.addthis.bundle.value.ValueArray;
+import com.addthis.bundle.value.ValueFactory;
+import com.addthis.bundle.value.ValueObject;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A value filter applies a transformation on a value and returns
+ * the result of the transformation.
+ *
+ * @user-reference
+ * @hydra-category
+ * @exclude-fields once, nullAccept
+ */
+public abstract class AbstractValueFilter implements ValueFilter {
+
+    /**
+     * Disables special {@link ValueArray} handling logic. By default (false), it will map over elements
+     * of an array. When this flag is turned on, filters will try to process the array as a whole.
+     * Default is false.
+     */
+    @JsonProperty protected boolean once;
+
+    public boolean getOnce() {
+        return once;
+    }
+
+    public ValueFilter setOnce(boolean o) {
+        once = o;
+        return this;
+    }
+
+    @Nullable private ValueObject filterArray(ValueObject value) {
+        ValueArray in = value.asArray();
+        ValueArray out = null;
+        for (ValueObject vo : in) {
+            ValueObject val = filterValue(vo);
+            if (val != null) {
+                if (out == null) {
+                    out = ValueFactory.createArray(in.size());
+                }
+                out.add(val);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Wrapper method for {@link #filterValue(ValueObject)} that has special logic for {@link ValueArray}s.
+     * This should be the primary method to be called in most circumstances, and should not be overridden unless
+     * special, different array handling logic is needed. When {@link #once} is true, or when the ValueObject
+     * is not an array, this is the same as directly calling {@link #filterValue(ValueObject)}.
+     */
+    @Override @Nullable public ValueObject filter(@Nullable ValueObject value) {
+        if (once) {
+            return filterValue(value);
+        }
+        // TODO why is this behaviour not there for TYPE.MAPS ?
+        if ((value != null) && (value.getObjectType() == ValueObject.TYPE.ARRAY)) {
+            return filterArray(value);
+        }
+        return filterValue(value);
+    }
+
+    @Nullable public abstract ValueObject filterValue(@Nullable ValueObject value);
+}

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/StringFilter.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/StringFilter.java
@@ -18,7 +18,7 @@ import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueObject;
 
 
-public abstract class StringFilter extends ValueFilter {
+public abstract class StringFilter extends AbstractValueFilter {
 
     public abstract String filter(String value);
 

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilter.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilter.java
@@ -15,107 +15,18 @@ package com.addthis.hydra.data.filter.value;
 
 import javax.annotation.Nullable;
 
-import com.addthis.bundle.value.ValueArray;
-import com.addthis.bundle.value.ValueFactory;
+import java.util.function.UnaryOperator;
+
 import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.Pluggable;
-import com.addthis.codec.codables.Codable;
-import com.addthis.codec.codables.SuperCodable;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-/**
- * A value filter applies a transformation on a value and returns
- * the result of the transformation.
- *
- * @user-reference
- * @hydra-category
- * @exclude-fields once, nullAccept
- */
+@FunctionalInterface
 @Pluggable("value-filter")
-public abstract class ValueFilter implements Codable {
+public interface ValueFilter extends UnaryOperator<ValueObject> {
 
-    /**
-     * Disables special {@link ValueArray} handling logic. By default (false), it will map over elements
-     * of an array. When this flag is turned on, filters will try to process the array as a whole.
-     * Default is false.
-     */
-    @JsonProperty protected boolean once;
-
-    /**
-     * If true then a parent {@link ValueFilterChain chain} filter does not exit on null values.
-     * This indicates that the filter wishes to accept a null
-     * returned by the previous filter in the chain. Default is false.
-     */
-    @JsonProperty protected boolean nullAccept;
-
-    public boolean getNullAccept() {
-        return nullAccept;
+    @Nullable @Override default ValueObject apply(ValueObject t) {
+        return filter(t);
     }
 
-    public boolean getOnce() {
-        return once;
-    }
-
-    public ValueFilter setOnce(boolean o) {
-        once = o;
-        return this;
-    }
-
-    @Nullable private ValueObject filterArray(ValueObject value) {
-        ValueArray in = value.asArray();
-        ValueArray out = null;
-        for (ValueObject vo : in) {
-            ValueObject val = filterValue(vo);
-            if (val != null) {
-                if (out == null) {
-                    out = ValueFactory.createArray(in.size());
-                }
-                out.add(val);
-            }
-        }
-        return out;
-    }
-
-    /**
-     * Wrapper method for {@link #filterValue(ValueObject)} that has special logic for {@link ValueArray}s.
-     * This should be the primary method to be called in most circumstances, and should not be overridden unless
-     * special, different array handling logic is needed. When {@link #once} is true, or when the ValueObject
-     * is not an array, this is the same as directly calling {@link #filterValue(ValueObject)}.
-     */
-    @Nullable public ValueObject filter(@Nullable ValueObject value) {
-        if (once) {
-            return filterValue(value);
-        }
-        // TODO why is this behaviour not there for TYPE.MAPS ?
-        if ((value != null) && (value.getObjectType() == ValueObject.TYPE.ARRAY)) {
-            return filterArray(value);
-        }
-        return filterValue(value);
-    }
-
-    /**
-     * The recommended pattern for initialization of ValueFilters is to
-     * use {@link JsonCreator} style constructors. See {@link ValueFilterTimeFormat}
-     * for an example of this pattern. This construction allows one to mark any
-     * appropriate fields as final fields which is a recommended best practice.
-     *
-     * ValueFilters may be instantiated and then never used again. For example
-     * this happens when we validate a job configuration in the user interface
-     * when a job is saved. Any stateful or expensive initialization, such as
-     * contacting a resource on the network or writing to a disk, should happen
-     * in this open method. Do not use {@link SuperCodable} for initialization
-     * of ValueFilters that is deprecated in favor of the approach described here.
-     *
-     * Any application using a ValueFilter must explicitly invoke the open
-     * method exactly once after the object has been initialized and before
-     * it is used. The best practice is to call the open method even if you
-     * know it performs no operation, as a future-proof for any changes to
-     * your application.
-     */
-    public abstract void open();
-
-    @Nullable public abstract ValueObject filterValue(@Nullable ValueObject value);
-
+    @Nullable ValueObject filter(@Nullable ValueObject value);
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBandPass.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBandPass.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">filters values that occur fewer than {@link #minHits minHits} times
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">filters values that occur fewer than {@link #minHits minHits} times
  * or more than {@link #maxHits maxHits} times</span>.
  * <p/>
  * <p>A value is emitted only after it has been observed for {@link #minHits minHits} instances.
@@ -72,9 +72,6 @@ public class ValueFilterBandPass extends StringFilter {
             return maxKeys > 0 && size() > maxKeys;
         }
     };
-
-    @Override
-    public void open() {}
 
     @Override
     public String filter(String value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBase64.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBase64.java
@@ -19,7 +19,7 @@ import com.addthis.basis.util.Strings;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">encodes or decodes a value to
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">encodes or decodes a value to
  * <a href="http://en.wikipedia.org/wiki/Base64">base64</a> format</span>.
  * <p/>
  * <p>Enabling <a href="#encode">encode</a> will encode the value to base64 format.
@@ -49,9 +49,6 @@ public class ValueFilterBase64 extends StringFilter {
      */
     @FieldConfig(codable = true)
     private boolean decode;
-
-    @Override
-    public void open() {}
 
     @Override
     public String filter(String value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBaseConv.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBaseConv.java
@@ -23,7 +23,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * Convert between bases with custom alphabet choices. Here "decode" means
  * return a 10-base String representation.
  */
-public class ValueFilterBaseConv extends ValueFilter {
+public class ValueFilterBaseConv extends AbstractValueFilter {
 
     @FieldConfig(codable = true)
     private boolean decode;
@@ -39,9 +39,6 @@ public class ValueFilterBaseConv extends ValueFilter {
         this.decode = decode;
         this.baseType = baseType;
     }
-
-    @Override
-    public void open() {}
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBitsToArray.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterBitsToArray.java
@@ -20,7 +20,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">converts the input into an array of
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">converts the input into an array of
  * integers</span>.
  * <p/>
  * <p>If the <i>n</i><sup>th</sup> bit is set in the bitwise representation of
@@ -35,7 +35,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name bit-split
  */
-public class ValueFilterBitsToArray extends ValueFilter {
+public class ValueFilterBitsToArray extends AbstractValueFilter {
 
     /**
      * If non-zero, then only return the bits from the mask.
@@ -71,9 +71,6 @@ public class ValueFilterBitsToArray extends ValueFilter {
         }
         return ret;
     }
-
-    @Override
-    public void open() {}
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCase.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCase.java
@@ -16,7 +16,7 @@ package com.addthis.hydra.data.filter.value;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">converts a value to lowercase or uppercase letters</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">converts a value to lowercase or uppercase letters</span>.
  * <p/>
  * <p>Enabling <a href="#lower">lower</a> will convert the input into lowercase latters.
  * Enabling <a href="#upper">upper</a> will convert the input into uppercase letters. If both
@@ -44,9 +44,6 @@ public class ValueFilterCase extends StringFilter {
      */
     @FieldConfig(codable = true)
     private boolean upper;
-
-    @Override
-    public void open() {}
 
     @Override
     public String filter(String value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCat.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCat.java
@@ -18,7 +18,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">perform pre- or post- string concatenation</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">perform pre- or post- string concatenation</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -28,7 +28,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name cat
  */
-public class ValueFilterCat extends ValueFilter {
+public class ValueFilterCat extends AbstractValueFilter {
 
     /**
      * If non-null, then prefix this string onto the beginning of the input.
@@ -41,9 +41,6 @@ public class ValueFilterCat extends ValueFilter {
      */
     @FieldConfig(codable = true)
     private String post;
-
-    @Override
-    public void open() {}
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterChain.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterChain.java
@@ -14,10 +14,11 @@
 package com.addthis.hydra.data.filter.value;
 
 import com.addthis.bundle.value.ValueObject;
-import com.addthis.codec.annotations.FieldConfig;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">executes a series of filters</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">executes a series of filters</span>.
  * <p/>
  * <p>By default the first filter to return null terminates the chain.
  * This can be overridden for the entire chain by setting {@link #nullStop nullStop}
@@ -35,36 +36,19 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name chain
  */
-public class ValueFilterChain extends ValueFilter {
+public class ValueFilterChain extends AbstractValueFilter {
 
     /**
      * The value filters to be performed in a chain.
      */
-    @FieldConfig(codable = true, required = true)
+    @JsonProperty(required = true)
     private ValueFilter[] filter;
-
-    /**
-     * If true, then terminate chain on first null output. Default is true.
-     */
-    @FieldConfig(codable = true)
-    private boolean nullStop = true;
-
-    @Override
-    public void open() {
-        for (ValueFilter f : filter) {
-            f.open();
-        }
-    }
 
     @Override
     public ValueObject filterValue(ValueObject value) {
         for (ValueFilter f : filter) {
-            if (value != null || !nullStop || f.getNullAccept()) {
-                value = f.filter(value);
-            } else {
-                return null;
-            }
+            value = f.filter(value);
         }
-        return value != null || !nullStop ? value : null;
+        return value;
     }
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterContains.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterContains.java
@@ -22,17 +22,15 @@ import com.addthis.bundle.util.ValueUtil;
 import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueMap;
 import com.addthis.bundle.value.ValueObject;
-import com.addthis.codec.annotations.FieldConfig;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import org.arabidopsis.ahocorasick.AhoCorasick;
 import org.arabidopsis.ahocorasick.SearchResult;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">checks for strings, arrays or maps
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">checks for strings, arrays or maps
  * that contain the target keys or values</span>.
  * <p/>
  * <p>If the input is a string then return the input if it is a substring of an element in {@link #value value},
@@ -55,7 +53,7 @@ import org.arabidopsis.ahocorasick.SearchResult;
  * @user-reference
  * @hydra-name contains
  */
-public class ValueFilterContains extends ValueFilter {
+public class ValueFilterContains extends AbstractValueFilter {
 
     /**
      * The set of values to match against.
@@ -89,10 +87,6 @@ public class ValueFilterContains extends ValueFilter {
         this.not = not;
         this.returnMatch = returnMatch;
         this.dictionary = (value != null) ? new AhoCorasick() : null;
-    }
-
-    @Override
-    public void open() {
         if (dictionary != null) {
             for (String pattern : value) {
                 dictionary.add(pattern);

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCounter.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCounter.java
@@ -19,13 +19,12 @@ import java.text.DecimalFormat;
 
 import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueObject;
-import com.addthis.codec.annotations.FieldConfig;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">counts the number of values it has observed</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">counts the number of values it has observed</span>.
  * <p/>
  * <p>The default behavior of this filter is to emit the count of the
  * number of values it has observed. If the {@link #sample sample} field is set
@@ -51,7 +50,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @user-reference
  * @hydra-name count
  */
-public class ValueFilterCounter extends ValueFilter {
+public class ValueFilterCounter extends AbstractValueFilter {
 
     private DecimalFormat dc;
 
@@ -88,9 +87,6 @@ public class ValueFilterCounter extends ValueFilter {
         this.sample = sample;
         counter.set(start);
     }
-
-    @Override
-    public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCreateMap.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterCreateMap.java
@@ -20,7 +20,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">extracts a map from a string</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">extracts a map from a string</span>.
  * <p/>
  * <p>The input string is expected to be a sequence of (key,value) pairs.
  * {@link #elementSeparator elementSeperator} is the deliminator in between
@@ -38,7 +38,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name create-map
  */
-public class ValueFilterCreateMap extends ValueFilter {
+public class ValueFilterCreateMap extends AbstractValueFilter {
 
     /**
      * This field is never used. Do with it what you want.
@@ -63,9 +63,6 @@ public class ValueFilterCreateMap extends ValueFilter {
      */
     @FieldConfig(codable = true)
     private boolean includeNullValues = false;
-
-    @Override
-    public void open() {}
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterDateRangeLength.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterDateRangeLength.java
@@ -28,7 +28,7 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">calculates the total numbers of days represented
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">calculates the total numbers of days represented
  * in the input string</span>.
  * <p/>
  * <p>The input string is a sequence of items, where an item is either
@@ -82,9 +82,6 @@ public class ValueFilterDateRangeLength extends StringFilter {
         this.dateSep = dateSep;
         this.diffUnit = diffUnit;
     }
-
-    @Override
-    public void open() {}
 
     @Override
     public String filter(String value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterDefault.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterDefault.java
@@ -20,7 +20,7 @@ import com.addthis.codec.annotations.FieldConfig;
 
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">provides a default value for a null input or an empty string</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">provides a default value for a null input or an empty string</span>.
  * <p/>
  * <p>If {@link #time time} is set to true, then the default value is set to the current wall clock
  * in unix milliseconds using the GMT timezone.
@@ -57,9 +57,6 @@ public class ValueFilterDefault extends StringFilter {
         value = dv;
         return this;
     }
-
-    @Override
-    public void open() {}
 
     @Override
     public String filter(String v) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterEmpty.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterEmpty.java
@@ -18,7 +18,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns the passed value if it is empty or null otherwise</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns the passed value if it is empty or null otherwise</span>.
  * <p/>
  * <p>By default this filter returns only empty values or null otherwise.
  * Specifying the parameter {@link #not not} as {@code true} inverts the
@@ -36,16 +36,13 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name empty
  */
-public class ValueFilterEmpty extends ValueFilter {
+public class ValueFilterEmpty extends AbstractValueFilter {
 
     /**
      * If true then return all non-empty elements. Default is false.
      */
     @FieldConfig(codable = true)
     private boolean not;
-
-    @Override
-    public void open() {}
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterError.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterError.java
@@ -15,12 +15,8 @@ package com.addthis.hydra.data.filter.value;
 
 import javax.annotation.Nullable;
 
-import java.lang.reflect.Constructor;
-
 import com.addthis.bundle.value.ValueObject;
-import com.addthis.codec.annotations.FieldConfig;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -33,7 +29,7 @@ import static com.fasterxml.jackson.annotation.JsonTypeInfo.As.EXTERNAL_PROPERTY
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.MINIMAL_CLASS;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">throws an exception</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">throws an exception</span>.
  * <p>This filter can be used either by developers when testing out the error handling
  * of the system or it can be used by users when they want to explicitly trigger the
  * error of a job.
@@ -46,7 +42,7 @@ import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.MINIMAL_CLASS;
  * @user-reference
  * @hydra-name error
  */
-public class ValueFilterError extends ValueFilter {
+public class ValueFilterError extends AbstractValueFilter {
 
     static final Logger log = LoggerFactory.getLogger(ValueFilterError.class);
 
@@ -59,7 +55,4 @@ public class ValueFilterError extends ValueFilter {
         throw Throwables.propagate(message);
     }
 
-    @Override public void open() {
-
-    }
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterEvalJava.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterEvalJava.java
@@ -151,6 +151,8 @@ public class ValueFilterEvalJava extends AbstractValueFilter implements SuperCod
 
     private ValueFilter constructedFilter;
 
+    private ValueFilterEvalJava() {}
+
     private static final Set<String> requiredImports = new HashSet<>();
 
     static {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterEvalJava.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterEvalJava.java
@@ -204,7 +204,6 @@ public class ValueFilterEvalJava extends AbstractValueFilter implements SuperCod
         classDecl.append(" extends AbstractValueFilter\n");
         classDecl.append("{\n");
         createConstructor(classDecl, className);
-        createInitializer(classDecl);
         createFilterValueMethod(classDecl);
         createFilterValueInternalMethod(classDecl);
         classDecl.append("}\n");
@@ -277,10 +276,6 @@ public class ValueFilterEvalJava extends AbstractValueFilter implements SuperCod
             classDecl.append("\n");
         }
         classDecl.append("}\n\n");
-    }
-
-    private void createInitializer(StringBuffer classDecl) {
-        classDecl.append("public void open() {}\n");
     }
 
     private void createFilterValueMethod(StringBuffer classDecl) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterExclude.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterExclude.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">excludes matching values</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">excludes matching values</span>.
  * <p/>
  * <p>This filter contains a number of fields. Each field performs a different type of matching.
  * If more that one field is used, then the input must match for all of the specified fields in

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterExclude.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterExclude.java
@@ -15,6 +15,8 @@ package com.addthis.hydra.data.filter.value;
 
 import java.util.HashSet;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -36,19 +38,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class ValueFilterExclude extends AbstractMatchStringFilter {
 
-    @JsonCreator
-    public ValueFilterExclude(@JsonProperty("value") HashSet<String> value,
-                              @JsonProperty("valueURL") String valueURL,
-                              @JsonProperty("match") HashSet<String> match,
-                              @JsonProperty("matchURL") String matchURL,
-                              @JsonProperty("find") HashSet<String> find,
-                              @JsonProperty("findURL") String findURL,
-                              @JsonProperty("contains") String[] contains,
-                              @JsonProperty("containsURL") String containsURL,
-                              @JsonProperty("urlReturnsCSV") boolean urlReturnsCSV,
-                              @JsonProperty("toLower") boolean toLower,
-                              @JsonProperty("urlTimeout") int urlTimeout,
-                              @JsonProperty("urlRetries") int urlRetries) {
+    @JsonCreator @VisibleForTesting
+    ValueFilterExclude(@JsonProperty("value") HashSet<String> value,
+                       @JsonProperty("valueURL") String valueURL,
+                       @JsonProperty("match") HashSet<String> match,
+                       @JsonProperty("matchURL") String matchURL,
+                       @JsonProperty("find") HashSet<String> find,
+                       @JsonProperty("findURL") String findURL,
+                       @JsonProperty("contains") String[] contains,
+                       @JsonProperty("containsURL") String containsURL,
+                       @JsonProperty("urlReturnsCSV") boolean urlReturnsCSV,
+                       @JsonProperty("toLower") boolean toLower,
+                       @JsonProperty("urlTimeout") int urlTimeout,
+                       @JsonProperty("urlRetries") int urlRetries) {
         super(value,
               valueURL,
               match,

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterGlob.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterGlob.java
@@ -22,7 +22,7 @@ import java.nio.file.Paths;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">performs glob expression matching on the input string</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">performs glob expression matching on the input string</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -40,8 +40,6 @@ public class ValueFilterGlob extends StringFilter {
     public ValueFilterGlob(@JsonProperty(value = "pattern", required = true) String pattern) {
         compiled = FileSystems.getDefault().getPathMatcher("glob:" + pattern);
     }
-
-    @Override public void open() { }
 
     @Override
     @Nullable

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterGrepTags.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterGrepTags.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Matches values to extracted tags from raw html.
  */
-public class ValueFilterGrepTags extends ValueFilter {
+public class ValueFilterGrepTags extends AbstractValueFilter {
     private static final Logger log = LoggerFactory.getLogger(ValueFilterGrepTags.class);
 
     /** Set of values to match against. */
@@ -51,8 +51,6 @@ public class ValueFilterGrepTags extends ValueFilter {
     @JsonProperty private int logEveryN = 100;
 
     private int parserErrors = 0;
-
-    @Override public void open() { }
 
     @Override
     @Nullable

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterHash.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterHash.java
@@ -27,7 +27,7 @@ import com.addthis.hydra.common.hash.PluggableHashFunction;
 import org.apache.commons.codec.binary.Hex;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns the hash of a value</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns the hash of a value</span>.
  * <p/>
  * <p>The {@link #type type} field determines what type of hash is calculated.
  * <p>
@@ -48,7 +48,7 @@ import org.apache.commons.codec.binary.Hex;
  * @user-reference
  * @hydra-name hash
  */
-public class ValueFilterHash extends ValueFilter {
+public class ValueFilterHash extends AbstractValueFilter {
 
     /**
      * The type of hashing method to use. Default is 1.
@@ -61,8 +61,6 @@ public class ValueFilterHash extends ValueFilter {
      */
     @FieldConfig(codable = true)
     private boolean abs;
-
-    @Override public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterHttpGet.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterHttpGet.java
@@ -29,9 +29,11 @@ import com.addthis.basis.util.Bytes;
 import com.addthis.basis.util.Files;
 import com.addthis.basis.util.Multidict;
 
+import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.Codec;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.codec.codables.Codable;
+import com.addthis.codec.codables.SuperCodable;
 import com.addthis.codec.json.CodecJSON;
 import com.addthis.hydra.common.hash.MD5HashFunction;
 
@@ -41,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class ValueFilterHttpGet extends StringFilter {
+public class ValueFilterHttpGet extends StringFilter implements SuperCodable {
 
     private static final Logger log   = LoggerFactory.getLogger(ValueFilterHttpGet.class);
     private static final Codec  codec = CodecJSON.INSTANCE;
@@ -92,7 +94,7 @@ public class ValueFilterHttpGet extends StringFilter {
     }
 
     @Override
-    public void open() {
+    public void postDecode() {
         if (persist) {
             persistTo = Files.initDirectory(persistDir);
             LinkedList<CacheObject> list = new LinkedList<>();
@@ -120,6 +122,18 @@ public class ValueFilterHttpGet extends StringFilter {
                 }
                 cache.put(cached.key, cached);
             }
+        }
+    }
+
+    @Override public void preEncode() {}
+
+    private static final class ValidationOnly extends ValueFilterHttpGet {
+        @Override public void postDecode() {
+            // intentionally do nothing
+        }
+
+        @Override public ValueObject filter(ValueObject value) {
+            throw new UnsupportedOperationException("This class is only intended for use in construction validation.");
         }
     }
 

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterHttpGet.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterHttpGet.java
@@ -76,6 +76,8 @@ public class ValueFilterHttpGet extends StringFilter implements SuperCodable {
     private AtomicBoolean               init  = new AtomicBoolean(false);
     private File persistTo;
 
+    private ValueFilterHttpGet() {}
+
     public static class CacheObject implements Codable, Comparable<CacheObject> {
 
         @FieldConfig(codable = true)

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterIndex.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterIndex.java
@@ -19,7 +19,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns the <i>i</i><sup>th</sup> element of an array</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns the <i>i</i><sup>th</sup> element of an array</span>.
  * <p/>
  * <p>The {@link #index index} specifies the 0-based offset of the element to retrieve.
  * A negative value for the index will retrieve the (-i) value from the opposite end of the array.
@@ -36,7 +36,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @hydra-name index
  * @exclude-fields once
  */
-public class ValueFilterIndex extends ValueFilter {
+public class ValueFilterIndex extends AbstractValueFilter {
 
     /**
      * The array offset of the element to return.
@@ -58,8 +58,6 @@ public class ValueFilterIndex extends ValueFilter {
         this.toNull = toNull;
         return this;
     }
-
-    @Override public void open() { }
 
     @Override
     public ValueObject filter(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterInequality.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterInequality.java
@@ -18,7 +18,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns those values that satisfies the specified inequalities</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns those values that satisfies the specified inequalities</span>.
  * <p/>
  * <p>The input value is placed on the left-hand side of the inequality.
  * The {@link #iop iop} field must be one of "lt" (&lt;), "lteq" (&lt;=), "eq" (==), "gteq" (&gt;=), or "gt" (&gt;).
@@ -35,7 +35,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @hydra-name inequality
  */
 
-public class ValueFilterInequality extends ValueFilter {
+public class ValueFilterInequality extends AbstractValueFilter {
 
     /**
      * The inequality to perform.
@@ -64,8 +64,6 @@ public class ValueFilterInequality extends ValueFilter {
         this.iop = iop;
         this.rh = rh;
     }
-
-    @Override public void open() { }
 
     // pass through if true, else null
     @Override

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterIntBase.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterIntBase.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">converts a number from one base to another</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">converts a number from one base to another</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * @user-reference
  * @hydra-name intbase
  */
-public class ValueFilterIntBase extends ValueFilter {
+public class ValueFilterIntBase extends AbstractValueFilter {
 
     private static final Logger log = LoggerFactory.getLogger(ValueFilterIntBase.class);
 
@@ -59,8 +59,6 @@ public class ValueFilterIntBase extends ValueFilter {
      */
     @FieldConfig(codable = true)
     private boolean inDouble = false;
-
-    @Override public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJSON.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJSON.java
@@ -58,6 +58,8 @@ public class ValueFilterJSON extends AbstractValueFilter implements SuperCodable
     private HotMap<String, Object> cache = new HotMap<>(new ConcurrentHashMap());
     private ArrayList<QueryToken> tokens;
 
+    private ValueFilterJSON() {}
+
     @Override
     public ValueObject filterValue(ValueObject value) {
         if ((value == null) || ((value.getObjectType() == ValueObject.TYPE.STRING) &&

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJSON.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJSON.java
@@ -27,7 +27,7 @@ import com.addthis.maljson.JSONArray;
 import com.addthis.maljson.JSONObject;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">parses JSON text into an object</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">parses JSON text into an object</span>.
  * <p/>
  * <p>
  * <p>Example:</p>
@@ -38,7 +38,7 @@ import com.addthis.maljson.JSONObject;
  * @user-reference
  * @hydra-name json
  */
-public class ValueFilterJSON extends ValueFilter implements SuperCodable {
+public class ValueFilterJSON extends AbstractValueFilter implements SuperCodable {
 
     @FieldConfig(codable = true)
     private int cacheSize = 1000;
@@ -57,8 +57,6 @@ public class ValueFilterJSON extends ValueFilter implements SuperCodable {
 
     private HotMap<String, Object> cache = new HotMap<>(new ConcurrentHashMap());
     private ArrayList<QueryToken> tokens;
-
-    @Override public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {
@@ -137,9 +135,7 @@ public class ValueFilterJSON extends ValueFilter implements SuperCodable {
         tokens.add(current);
     }
 
-    @Override
-    public void preEncode() {
-    }
+    @Override public void preEncode() {}
 
     private static class QueryToken {
 

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJavascript.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJavascript.java
@@ -31,6 +31,8 @@ public class ValueFilterJavascript extends StringFilter implements SuperCodable 
     private String source;
     private Filter filter;
 
+    private ValueFilterJavascript() {}
+
     @Override public void postDecode() {
         if (source == null) {
             throw new IllegalArgumentException("no source specified!");

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJavascript.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJavascript.java
@@ -17,6 +17,7 @@ import javax.script.Invocable;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 
+import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.codec.codables.SuperCodable;
 
@@ -24,13 +25,13 @@ import com.addthis.codec.codables.SuperCodable;
  * Value filter based on the JSR 223 scripting interface, and the default
  * implementation based on Rhino, shipped with the 1.6 JDK.
  */
-public class ValueFilterJavascript extends StringFilter {
+public class ValueFilterJavascript extends StringFilter implements SuperCodable {
 
     @FieldConfig(codable = true)
     private String source;
     private Filter filter;
 
-    @Override public void open() {
+    @Override public void postDecode() {
         if (source == null) {
             throw new IllegalArgumentException("no source specified!");
         }
@@ -61,6 +62,18 @@ public class ValueFilterJavascript extends StringFilter {
         }
 
         filter = ((Invocable) engine).getInterface(Filter.class);
+    }
+
+    @Override public void preEncode() {}
+
+    private static final class ValidationOnly extends ValueFilterJavascript {
+        @Override public void postDecode() {
+            // intentionally do nothing
+        }
+
+        @Override public ValueObject filter(ValueObject value) {
+            throw new UnsupportedOperationException("This class is only intended for use in construction validation.");
+        }
     }
 
     @Override

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJoin.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterJoin.java
@@ -22,7 +22,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">joins an array or a map to a string</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">joins an array or a map to a string</span>.
  * <p/>
  * <p>Items of the sequence are separated by the {@link #join join} field.
  * If the input is a map, then (key, value) pairs are separated by the {@link #keyJoin keyJoin} field.
@@ -42,7 +42,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @hydra-name join
  * @exclude-fields once
  */
-public class ValueFilterJoin extends ValueFilter {
+public class ValueFilterJoin extends AbstractValueFilter {
 
     /**
      * The deliminator between elements in the output string. Default is "," .
@@ -98,15 +98,6 @@ public class ValueFilterJoin extends ValueFilter {
     public ValueFilterJoin setSort(boolean sort) {
         this.sort = sort;
         return this;
-    }
-
-    @Override public void open() {
-        if (filter != null) {
-            filter.open();
-        }
-        if (keyFilter != null) {
-            keyFilter.open();
-        }
     }
 
     @Override

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterLength.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterLength.java
@@ -20,9 +20,9 @@ import com.addthis.bundle.value.ValueObject;
 
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns the length of the array, map or string</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns the length of the array, map or string</span>.
  * <p/>
- * <p>To get the length of an array, the {@link ValueFilter#once once} field must be enabled,
+ * <p>To get the length of an array, the {@link AbstractValueFilter#once once} field must be enabled,
  * otherwise the filter attempts to iterate over the array elements.
  * <p>Example:</p>
  * <pre>
@@ -32,9 +32,7 @@ import com.addthis.bundle.value.ValueObject;
  * @user-reference
  * @hydra-name length
  */
-public class ValueFilterLength extends ValueFilter {
-
-    @Override public void open() { }
+public class ValueFilterLength extends AbstractValueFilter {
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterListApply.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterListApply.java
@@ -19,7 +19,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">applies the filter argument to each element of the input list</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">applies the filter argument to each element of the input list</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -29,17 +29,13 @@ import com.addthis.codec.annotations.FieldConfig;
  * @hydra-name list-apply
  * @exclude-fields once
  */
-public class ValueFilterListApply extends ValueFilter {
+public class ValueFilterListApply extends AbstractValueFilter {
 
     /**
      * The filter to be applied to each element of the input list.
      */
     @FieldConfig(codable = true, required = true)
     private ValueFilter elementFilter;
-
-    @Override public void open() {
-        elementFilter.open();
-    }
 
     @Override
     // This is a essentially a copy of the default ValueFilter.filter (which applies filterValue to list elements).

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMD5.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMD5.java
@@ -18,7 +18,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.hydra.common.hash.MD5HashFunction;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns the MD5 sum of the input</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns the MD5 sum of the input</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -28,9 +28,7 @@ import com.addthis.hydra.common.hash.MD5HashFunction;
  * @user-reference
  * @hydra-name md5
  */
-public class ValueFilterMD5 extends ValueFilter {
-
-    @Override public void open() { }
+public class ValueFilterMD5 extends AbstractValueFilter {
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMap.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMap.java
@@ -20,6 +20,8 @@ import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.codec.codables.SuperCodable;
 import com.addthis.hydra.data.util.JSONFetcher;
 
+import com.google.common.annotations.VisibleForTesting;
+
 
 /**
  * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">uses the input as a key and returns the value
@@ -79,6 +81,9 @@ public class ValueFilterMap extends StringFilter implements SuperCodable {
      */
     @FieldConfig(codable = true)
     private boolean httpTrace;
+
+    @VisibleForTesting
+    ValueFilterMap() {}
 
     public ValueFilterMap setMap(HashMap<String, String> map) {
         this.map = map;

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMap.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMap.java
@@ -15,12 +15,14 @@ package com.addthis.hydra.data.filter.value;
 
 import java.util.HashMap;
 
+import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
+import com.addthis.codec.codables.SuperCodable;
 import com.addthis.hydra.data.util.JSONFetcher;
 
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">uses the input as a key and returns the value
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">uses the input as a key and returns the value
  * associated with the input in a specified map</span>.
  * <p/>
  * <p>The map is specified with the {@link #map map} field. Alternatively a JSON map
@@ -38,7 +40,7 @@ import com.addthis.hydra.data.util.JSONFetcher;
  * @user-reference
  * @hydra-name map
  */
-public class ValueFilterMap extends StringFilter {
+public class ValueFilterMap extends StringFilter implements SuperCodable {
 
     /**
      * The map used to search for the input key.
@@ -109,9 +111,21 @@ public class ValueFilterMap extends StringFilter {
     }
 
     @Override
-    public void open() {
+    public void postDecode() {
         if (map == null && mapURL != null) {
             map = new JSONFetcher(httpTimeout, httpTrace).loadMap(mapURL);
+        }
+    }
+
+    @Override public void preEncode() {}
+
+    private static final class ValidationOnly extends ValueFilterMap {
+        @Override public void postDecode() {
+            // intentionally do nothing
+        }
+
+        @Override public ValueObject filter(ValueObject value) {
+            throw new UnsupportedOperationException("This class is only intended for use in construction validation.");
         }
     }
 

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMapSubset.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMapSubset.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">accepts a map as input and then performs
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">accepts a map as input and then performs
  * filtering operations on the input</span>.
  * <p/>
  * <p>If the {@link #whitelist whitelist} field is non-null, then any keys outside
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  * @user-reference
  * @hydra-name map-subset
  */
-public class ValueFilterMapSubset extends ValueFilter {
+public class ValueFilterMapSubset extends AbstractValueFilter {
     private static final Logger log = LoggerFactory.getLogger(ValueFilterMapSubset.class);
 
     /** Set of keys that are preserved by the filter. */
@@ -74,8 +74,6 @@ public class ValueFilterMapSubset extends ValueFilter {
     /** If toString is true, then use this field as the deliminator between two (key,value) pairs. */
     @JsonProperty private String valueSep = ",";
 
-
-    @Override public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMapValue.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMapValue.java
@@ -18,7 +18,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns the value associated with a specific key
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns the value associated with a specific key
  * from the input map</span>.
  * <p>A value of null is returned if the key is not present in the map.
  * <p>Example:</p>
@@ -29,15 +29,13 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name map-value
  */
-public class ValueFilterMapValue extends ValueFilter {
+public class ValueFilterMapValue extends AbstractValueFilter {
 
     /**
      * The key to match from the input map.
      */
     @FieldConfig(codable = true)
     private String key;
-
-    @Override public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMod.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterMod.java
@@ -20,7 +20,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns the modulo of the input</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns the modulo of the input</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -30,7 +30,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name mod
  */
-public class ValueFilterMod extends ValueFilter {
+public class ValueFilterMod extends AbstractValueFilter {
 
     /**
      * The modulus of the operation.
@@ -43,8 +43,6 @@ public class ValueFilterMod extends ValueFilter {
      */
     @FieldConfig(codable = true)
     private boolean abs = true;
-
-    @Override public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterNot.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterNot.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">negates another value filter</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">negates another value filter</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -30,27 +30,23 @@ import com.fasterxml.jackson.annotation.JsonCreator;
  * @user-reference
  * @hydra-name not
  */
-public class ValueFilterNot extends ValueFilter {
+public class ValueFilterNot extends AbstractValueFilter {
 
     private final ValueFilter filter;
 
     @JsonCreator public ValueFilterNot(ValueFilter filter) {
         this.filter = filter;
-        this.once = filter.once;
-        this.nullAccept = filter.nullAccept;
     }
 
-    @Override public void open() {
-        filter.open();
-    }
-
-    @Override
-    @Nullable
-    public ValueObject filterValue(@Nullable ValueObject value) {
-        if (filter.filterValue(value) == null) {
+    @Override @Nullable public ValueObject filter(@Nullable ValueObject value) {
+        if (filter.filter(value) == null) {
             return value;
         } else {
             return null;
         }
+    }
+
+    @Nullable @Override public ValueObject filterValue(@Nullable ValueObject value) {
+        return filter.filter(value);
     }
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterPad.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterPad.java
@@ -16,7 +16,7 @@ package com.addthis.hydra.data.filter.value;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">applies left or right string padding</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">applies left or right string padding</span>.
  * <p/>
  * <p>If the input string is shorter than the padding string, then the input
  * string is lengthened by filling in the characters from the padding. For example,
@@ -47,8 +47,6 @@ public class ValueFilterPad extends StringFilter {
      */
     @FieldConfig(codable = true)
     private String right;
-
-    @Override public void open() { }
 
     @Override
     public String filter(String v) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterPass.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterPass.java
@@ -16,7 +16,7 @@ package com.addthis.hydra.data.filter.value;
 import com.addthis.bundle.value.ValueObject;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns the input value</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns the input value</span>.
  * <p/>
  * <p>No transformations are performed in the input value. It is passed along as the output value.</p>
  * <p/>
@@ -29,9 +29,7 @@ import com.addthis.bundle.value.ValueObject;
  * @hydra-name pass
  * @exclude-fields once
  */
-public class ValueFilterPass extends ValueFilter {
-
-    @Override public void open() { }
+public class ValueFilterPass extends AbstractValueFilter {
 
     @Override
     public ValueObject filter(ValueObject v) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRandom.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRandom.java
@@ -22,7 +22,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns a random number</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns a random number</span>.
  * <p/>
  * <p>The input value to this filter is ignored. By default, this filter produces a random
  * number from a uniform distribution in the range (0, {@link #max max}]. A long value is
@@ -38,7 +38,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name random
  */
-public class ValueFilterRandom extends ValueFilter {
+public class ValueFilterRandom extends AbstractValueFilter {
 
     private final Random random = new Random();
 
@@ -88,8 +88,6 @@ public class ValueFilterRandom extends ValueFilter {
     private boolean asFloat;
 
     private DecimalFormat format;
-
-    @Override public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRange.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRange.java
@@ -16,7 +16,7 @@ package com.addthis.hydra.data.filter.value;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns a substring of the string input</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns a substring of the string input</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -45,8 +45,6 @@ public class ValueFilterRange extends StringFilter {
         this.end = end;
         return this;
     }
-
-    @Override public void open() { }
 
     @Override
     public String filter(String sv) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRegex.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRegex.java
@@ -23,7 +23,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">performs regular expression matching on the input string</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">performs regular expression matching on the input string</span>.
  * <p/>
  * <p>The default behavior is to perform regular expression matching on the input string,
  * and return an array with all the substrings that match to the regular expression.
@@ -55,7 +55,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name regex
  */
-public class ValueFilterRegex extends ValueFilter {
+public class ValueFilterRegex extends AbstractValueFilter {
 
     /**
      * Regular expression to match against. This field is required.
@@ -78,9 +78,6 @@ public class ValueFilterRegex extends ValueFilter {
         replace = r;
         return this;
     }
-
-    @Override
-    public void open() {}
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterReplace.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterReplace.java
@@ -16,13 +16,11 @@ package com.addthis.hydra.data.filter.value;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.addthis.codec.annotations.FieldConfig;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">performs string replacement with optional regular expression matching</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">performs string replacement with optional regular expression matching</span>.
  * <p/>
  * <p>The default behavior is to perform literal string replacement. If the {@link #regex regex} field
  * is enabled, then the find pattern is interpreted as a regular expression.
@@ -68,9 +66,6 @@ public class ValueFilterReplace extends StringFilter {
             this.replace = (replace != null) ? Matcher.quoteReplacement(replace) : null;
         }
     }
-
-    @Override
-    public void open() { }
 
     @Override
     public String filter(String value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRequire.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRequire.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">filters the input based on one or more string-matching criteria</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">filters the input based on one or more string-matching criteria</span>.
  * <p/>
  * <p>One or more of the following filtering fields can be used:</p>
  * <p>
@@ -74,4 +74,5 @@ public class ValueFilterRequire extends AbstractMatchStringFilter {
               urlRetries,
               false);
     }
+
 }

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRequire.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRequire.java
@@ -15,6 +15,8 @@ package com.addthis.hydra.data.filter.value;
 
 import java.util.HashSet;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -47,19 +49,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class ValueFilterRequire extends AbstractMatchStringFilter {
 
-    @JsonCreator
-    public ValueFilterRequire(@JsonProperty("value") HashSet<String> value,
-                              @JsonProperty("valueURL") String valueURL,
-                              @JsonProperty("match") HashSet<String> match,
-                              @JsonProperty("matchURL") String matchURL,
-                              @JsonProperty("find") HashSet<String> find,
-                              @JsonProperty("findURL") String findURL,
-                              @JsonProperty("contains") String[] contains,
-                              @JsonProperty("containsURL") String containsURL,
-                              @JsonProperty("urlReturnsCSV") boolean urlReturnsCSV,
-                              @JsonProperty("toLower") boolean toLower,
-                              @JsonProperty("urlTimeout") int urlTimeout,
-                              @JsonProperty("urlRetries") int urlRetries) {
+    @JsonCreator @VisibleForTesting
+    ValueFilterRequire(@JsonProperty("value") HashSet<String> value,
+                       @JsonProperty("valueURL") String valueURL,
+                       @JsonProperty("match") HashSet<String> match,
+                       @JsonProperty("matchURL") String matchURL,
+                       @JsonProperty("find") HashSet<String> find,
+                       @JsonProperty("findURL") String findURL,
+                       @JsonProperty("contains") String[] contains,
+                       @JsonProperty("containsURL") String containsURL,
+                       @JsonProperty("urlReturnsCSV") boolean urlReturnsCSV,
+                       @JsonProperty("toLower") boolean toLower,
+                       @JsonProperty("urlTimeout") int urlTimeout,
+                       @JsonProperty("urlRetries") int urlRetries) {
         super(value,
               valueURL,
               match,

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterReverse.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterReverse.java
@@ -18,7 +18,7 @@ import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueObject;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">reverses a string or an array</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">reverses a string or an array</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -28,10 +28,7 @@ import com.addthis.bundle.value.ValueObject;
  * @user-reference
  * @hydra-name reverse
  */
-public class ValueFilterReverse extends ValueFilter {
-
-    @Override
-    public void open() { }
+public class ValueFilterReverse extends AbstractValueFilter {
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSeen.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSeen.java
@@ -24,7 +24,7 @@ import com.addthis.hydra.store.util.Raw;
 import com.addthis.hydra.store.util.SeenFilterBasic;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">filters to elements seen or not seen by a basic bloom filter</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">filters to elements seen or not seen by a basic bloom filter</span>.
  * <p/>
  * <p>{@link ValueFilterBloom ValueFilterBloom} is similar and uses a better bloom implementation,
  * but requires a lot work to make jobs 360 wrt gen/use of blooms.
@@ -36,7 +36,7 @@ import com.addthis.hydra.store.util.SeenFilterBasic;
  * @user-reference
  * @hydra-name seen
  */
-public class ValueFilterSeen extends ValueFilter {
+public class ValueFilterSeen extends AbstractValueFilter {
 
     /**
      * If true, then return elements detected in the Bloom filter. Otherwise return elements
@@ -77,13 +77,6 @@ public class ValueFilterSeen extends ValueFilter {
         }
         {
             return match ? null : value;
-        }
-    }
-
-    @Override
-    public void open() {
-        if (filter != null) {
-            filter.open();
         }
     }
 

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSerial.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSerial.java
@@ -18,7 +18,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">auto-generates key sequences</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">auto-generates key sequences</span>.
  * <p/>
  * <p>This filter ignores the input value. The output is an incrementing counter.
  * The {@link #seed seed} field is the starting value in the sequence.
@@ -35,7 +35,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @user-reference
  * @hydra-name serial
  */
-public class ValueFilterSerial extends ValueFilter {
+public class ValueFilterSerial extends AbstractValueFilter {
 
     /**
      * If non-null, then append this prefix onto the output. Default is null.
@@ -66,9 +66,6 @@ public class ValueFilterSerial extends ValueFilter {
      */
     @FieldConfig(codable = true)
     private int base;
-
-    @Override
-    public void open() { }
 
     @Override
     public synchronized ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSet.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSet.java
@@ -15,13 +15,12 @@ package com.addthis.hydra.data.filter.value;
 
 import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueObject;
-import com.addthis.codec.annotations.FieldConfig;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns a constant value</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns a constant value</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -31,7 +30,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @user-reference
  * @hydra-name set
  */
-public class ValueFilterSet extends ValueFilter {
+public class ValueFilterSet extends AbstractValueFilter {
 
     /**
      * The output value.
@@ -45,9 +44,6 @@ public class ValueFilterSet extends ValueFilter {
         this.value = value;
         this.cache = ValueFactory.create(value);
     }
-
-    @Override
-    public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject v) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSlice.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSlice.java
@@ -20,7 +20,7 @@ import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns a subset of the string or array input</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns a subset of the string or array input</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -31,7 +31,7 @@ import com.addthis.codec.annotations.FieldConfig;
  * @hydra-name slice
  * @exlude-fields once
  */
-public class ValueFilterSlice extends ValueFilter {
+public class ValueFilterSlice extends AbstractValueFilter {
 
     /**
      * The start position of the subset in a 0-based offset (inclusive). Default is 0.
@@ -59,9 +59,6 @@ public class ValueFilterSlice extends ValueFilter {
         this.to = to;
         this.inc = inc;
     }
-
-    @Override
-    public void open() { }
 
     @Override
     public ValueObject filter(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSort.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSort.java
@@ -23,13 +23,13 @@ import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueObject;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">sorts an array</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">sorts an array</span>.
  * <p/>
  * <p>Items in the array are sorted according to the natural ordering of their underlying type.
  * Only arrays with elements of TYPE STRING, INT, or FLOAT are supported. All elements of the array must be from the same type.
  * </p>
  */
-public class ValueFilterSort extends ValueFilter {
+public class ValueFilterSort extends AbstractValueFilter {
 
     private static final Comparator<ValueObject> valueObjectComparator = (o1, o2) -> {
         if (o1.getObjectType() != o2.getObjectType()) {
@@ -46,9 +46,6 @@ public class ValueFilterSort extends ValueFilter {
                 throw new RuntimeException("Sort error: unsupported object type " + o1.getObjectType());
         }
     };
-
-    @Override
-    public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSplit.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterSplit.java
@@ -33,7 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">splits the input into an array or a map</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">splits the input into an array or a map</span>.
  * <p/>
  * <p>The input must be a string. The {@link #split split} field or the
  * {@link #fixedLength fixedLength} field is used to divide the input into a sequence
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * @hydra-name split
  * @exclude-fields once
  */
-public class ValueFilterSplit extends ValueFilter {
+public class ValueFilterSplit extends AbstractValueFilter {
 
     private static final Logger log = LoggerFactory.getLogger(ValueFilterSplit.class);
     private static final boolean ERROR_ON_ARRAY = Parameter.boolValue("hydra.filter.split.error", false);
@@ -117,17 +117,6 @@ public class ValueFilterSplit extends ValueFilter {
         this.fixedLength = fixedLength;
         return this;
     }
-
-    @Override
-    public void open() {
-        if (filter != null) {
-            filter.open();
-        }
-        if (keyFilter != null) {
-            keyFilter.open();
-        }
-    }
-
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterStringSlice.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterStringSlice.java
@@ -25,7 +25,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Iterators;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">splits the input string into an output string</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">splits the input string into an output string</span>.
  * <p/>
  * <p>The input string is interpreted as a sequence of items that are separated by
  * {@link #sep sep}. A subsequence of the input is extracted and the output string
@@ -79,9 +79,6 @@ public class ValueFilterStringSlice extends StringFilter {
         this.fromIndex = fromIndex;
         this.toIndex = toIndex;
     }
-
-    @Override
-    public void open() { }
 
     @Override
     public String filter(String value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterTimeFormat.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterTimeFormat.java
@@ -15,15 +15,13 @@ package com.addthis.hydra.data.filter.value;
 
 
 import com.addthis.bundle.value.ValueObject;
-import com.addthis.codec.annotations.FieldConfig;
-import com.addthis.codec.codables.SuperCodable;
 import com.addthis.hydra.data.util.TimeField;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">accepts a time string and converts the time into another format</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">accepts a time string and converts the time into another format</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -33,7 +31,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @user-reference
  * @hydra-name time-format
  */
-public class ValueFilterTimeFormat extends ValueFilter {
+public class ValueFilterTimeFormat extends AbstractValueFilter {
 
     /**
      * The input format using the
@@ -76,9 +74,6 @@ public class ValueFilterTimeFormat extends ValueFilter {
         this.in = new TimeField(null, formatIn, timeZoneIn);
         this.out = new TimeField(null, formatOut, timeZoneOut);
     }
-
-    @Override
-    public void open() { }
 
     @Override
     public ValueObject filterValue(ValueObject value) {

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterTimeRange.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterTimeRange.java
@@ -21,7 +21,6 @@ import com.addthis.bundle.util.ValueUtil;
 import com.addthis.bundle.value.ValueArray;
 import com.addthis.bundle.value.ValueFactory;
 import com.addthis.bundle.value.ValueObject;
-import com.addthis.codec.annotations.FieldConfig;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -33,7 +32,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">returns one or more formatted time values</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">returns one or more formatted time values</span>.
  * <p/>
  * <p>The input to this filter is assumed to be a date in Unix milliseconds.
  * This behavior can be changed using the {@link #now now} or {@link #defaultNow defaultNow} fields.
@@ -62,7 +61,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * @user-reference
  * @hydra-name time-range
  */
-public class ValueFilterTimeRange extends ValueFilter {
+public class ValueFilterTimeRange extends AbstractValueFilter {
 
     /**
      * The output format using the
@@ -122,9 +121,6 @@ public class ValueFilterTimeRange extends ValueFilter {
         this.now = now;
         this.date = DateTimeFormat.forPattern(format);
     }
-
-    @Override
-    public void open() { }
 
     private ValueArray getTimeRange(long time, int range, TimeUnit timeUnit) {
         ValueArray arr = ValueFactory.createArray(range);

--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterTrim.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterTrim.java
@@ -17,7 +17,7 @@ import com.addthis.basis.util.Strings;
 
 
 /**
- * This {@link ValueFilter ValueFilter} <span class="hydra-summary">eliminates whitespace from the beginning and end of the input string</span>.
+ * This {@link AbstractValueFilter ValueFilter} <span class="hydra-summary">eliminates whitespace from the beginning and end of the input string</span>.
  * <p/>
  * <p>Example:</p>
  * <pre>
@@ -28,9 +28,6 @@ import com.addthis.basis.util.Strings;
  * @hydra-name trim
  */
 public class ValueFilterTrim extends StringFilter {
-
-    @Override
-    public void open() { }
 
     @Override
     public String filter(String value) {

--- a/hydra-filters/src/main/resources/reference.conf
+++ b/hydra-filters/src/main/resources/reference.conf
@@ -107,6 +107,10 @@ plugins {
 
 }
 
+# 'hydra.validation' is used to override the global config namespace only during
+# validation of job configs in certain spawn methods (see: JobsResource). It is
+# primarily intended to allow certain expensive object construction steps to be
+# skipped when they are not needed.
 hydra.validation.plugins {
   bundle-filter {
     http: "AbstractBundleFilterHttp$ValidationBundleFilterHttp"

--- a/hydra-filters/src/main/resources/reference.conf
+++ b/hydra-filters/src/main/resources/reference.conf
@@ -107,6 +107,25 @@ plugins {
 
 }
 
+hydra.validation.plugins {
+  bundle-filter {
+    http: "AbstractBundleFilterHttp$ValidationBundleFilterHttp"
+  }
+
+  closeable bundle filter {
+    delete: com.addthis.hydra.data.filter.closeablebundle.BundleFilterAlwaysValidates
+  }
+
+  value-filter {
+    validate-require-exclude._class: "AbstractMatchStringFilter$ValidationOnly"
+    exclude._class: validate-require-exclude
+    require._class: validate-require-exclude
+    httpget._class: "ValueFilterHttpGet$ValidationOnly"
+    javascript._class: "ValueFilterJavascript$ValidationOnly"
+    map._class: "ValueFilterMap$ValidationOnly"
+  }
+}
+
 com.addthis.hydra.data.filter.value.ValueFilterCounter {
   increment: 1
 }

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterGlob.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterGlob.java
@@ -26,7 +26,7 @@ public class TestValueFilterGlob {
 
     @Test
     public void deser() throws IOException {
-        ValueFilterGlob filter = (ValueFilterGlob) Configs.decodeObject(ValueFilter.class, "glob = \"tr?an{g,z}l*\"");
+        ValueFilterGlob filter = (ValueFilterGlob) Configs.decodeObject(AbstractValueFilter.class, "glob = \"tr?an{g,z}l*\"");
     }
 
     @Test

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterMap.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/TestValueFilterMap.java
@@ -24,7 +24,7 @@ public class TestValueFilterMap {
 
     private String mapFilter(String val, HashMap<String, String> map, String mapURL, boolean tonull) {
         ValueFilterMap filter = new ValueFilterMap().setMap(map).setMapURL(mapURL).setToNull(tonull);
-        filter.open();
+        filter.postDecode();
         return filter.filter(val);
     }
 

--- a/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/ValueFilterNotTest.java
+++ b/hydra-filters/src/test/java/com/addthis/hydra/data/filter/value/ValueFilterNotTest.java
@@ -26,8 +26,8 @@ public class ValueFilterNotTest {
     @Test
     public void inversion() throws Exception {
         ValueFilter filter = Configs.decodeObject(ValueFilter.class, "not.glob = \"foo*\"");
-        assertNull(filter.filterValue(create("foobar")));
-        assertNotNull(filter.filterValue(create("notfoo")));
-        assertNotNull(filter.filterValue(create("goodbar")));
+        assertNull(filter.filter(create("foobar")));
+        assertNotNull(filter.filter(create("notfoo")));
+        assertNotNull(filter.filter(create("goodbar")));
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/alert/JobAlertUtil.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/alert/JobAlertUtil.java
@@ -189,7 +189,6 @@ public class JobAlertUtil {
         BundleFilter bFilter = null;
         try {
             bFilter = CodecJSON.decodeString(BundleFilter.class, filter);
-            bFilter.open();
         } catch (Exception ex) {
             errorBuilder.append("Error attempting to create bundle filter: " + ex + "\n");
             log.error("Error attempting to create bundle filter", ex);

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/CloseableBundleFilterStreamBuilder.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/CloseableBundleFilterStreamBuilder.java
@@ -36,9 +36,6 @@ public class CloseableBundleFilterStreamBuilder extends StreamBuilder {
 
     @Override
     public void init() {
-        if (cfilter != null) {
-            cfilter.open();
-        }
     }
 
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/EachStreamBuilder.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/EachStreamBuilder.java
@@ -34,9 +34,6 @@ public class EachStreamBuilder extends StreamBuilder {
 
     @Override
     public void init() {
-        if (emitFilter != null) {
-            emitFilter.open();
-        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/FieldFilter.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/FieldFilter.java
@@ -63,12 +63,6 @@ public final class FieldFilter {
         }
     }
 
-    public void open() {
-        if (filter != null) {
-            filter.open();
-        }
-    }
-
     // can't find a good way to copy the json value for "from", copy constructors fail for abstract types,
     // and clone has its own host of problems. We could just re-use the same object, but that would be even
     // more wasteful than the caching we perform for unchanging formats. This is a decent stop-gap solution.

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/MapDef.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/MapDef.java
@@ -63,16 +63,5 @@ public final class MapDef {
     @JsonProperty FieldFilter[] fields;
 
     public void init() {
-        if (filterIn != null) {
-            filterIn.open();
-        }
-        if (filterOut != null) {
-            filterOut.open();
-        }
-        if (fields != null) {
-            for(FieldFilter field : fields) {
-                field.open();
-            }
-        }
     }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/SortedDeDupBuilder.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/SortedDeDupBuilder.java
@@ -53,9 +53,6 @@ public class SortedDeDupBuilder extends StreamBuilder {
 
     @Override
     public void init() {
-        if (filter != null) {
-            filter.open();
-        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamRowSplitBuilder.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamRowSplitBuilder.java
@@ -34,9 +34,6 @@ public class StreamRowSplitBuilder extends StreamBuilder {
 
     @Override
     public void init() {
-        if (filter != null) {
-            filter.open();
-        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractDataOutput.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractDataOutput.java
@@ -82,9 +82,6 @@ public abstract class AbstractDataOutput extends DataOutputTypeList {
         if (writer != null) {
             writer.open();
         }
-        if (filter != null) {
-            filter.open();
-        }
         if (dataPurgeConfig != null) {
             purgeData();
         }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractFilteredOutput.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractFilteredOutput.java
@@ -25,9 +25,6 @@ public abstract class AbstractFilteredOutput extends TaskDataOutput {
 
     @Override
     protected void open() {
-        if (filter != null) {
-            filter.open();
-        }
     }
 
     public boolean filter(Bundle bundle) {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractOutputWriter.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractOutputWriter.java
@@ -171,10 +171,6 @@ public abstract class AbstractOutputWriter {
             format.open();
         }
 
-        if (filter != null) {
-            filter.open();
-        }
-
         /**
          * The next several lines of logic are to handle
          * ridiculous input values for maxBundles and bufferSizeRatio.

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/FilteredDataOutput.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/FilteredDataOutput.java
@@ -49,9 +49,6 @@ public class FilteredDataOutput extends TaskDataOutput {
 
     @Override
     protected void open() {
-        if (filter != null) {
-            filter.open();
-        }
         output.open();
     }
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputStreamColumnized.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputStreamColumnized.java
@@ -54,9 +54,6 @@ public class OutputStreamColumnized extends OutputStreamFormatter implements Sup
 
     @Override
     public void open() {
-        if (filter != null) {
-            filter.open();
-        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathElement.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathElement.java
@@ -192,9 +192,6 @@ public abstract class PathElement implements Codable, TreeDataParent {
             label = new PathValue(intern(name));
             label.count = count;
         }
-        if (filter != null) {
-            filter.open();
-        }
     }
 
     public final boolean isOp() {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathFile.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathFile.java
@@ -139,9 +139,6 @@ public final class PathFile extends PathKeyValue {
             }
             tokens = new Tokenizer().setSeparator(separator).setPacking(true);
         }
-        if (tokenFilter != null) {
-            tokenFilter.open();
-        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathKeyValue.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathKeyValue.java
@@ -75,9 +75,6 @@ public class PathKeyValue extends PathValue {
     public void resolve(TreeMapper mapper) {
         super.resolve(mapper);
         keyAccess = mapper.bindField(key);
-        if (prefilter != null) {
-            prefilter.open();
-        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathValue.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/PathValue.java
@@ -137,9 +137,6 @@ public class PathValue extends PathElement {
         if (each != null) {
             each.resolve(mapper);
         }
-        if (vfilter != null) {
-            vfilter.open();
-        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/run/TaskRunner.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/run/TaskRunner.java
@@ -73,6 +73,10 @@ public class TaskRunner {
         }
     }
 
+    public static TaskRunnable makeTask(String configString) throws JsonProcessingException, IOException {
+        return makeTask(configString, Jackson.defaultCodec());
+    }
+
     /**
      * Creates a TaskRunnable using CodecConfig and a little custom handling. At the root
      * level object, if there is a field named "global", then that sub tree is hoisted
@@ -81,7 +85,8 @@ public class TaskRunner {
      * properties for the purposes of variable substitution. This will not merge them entirely
      * though and so the job config will be otherwise unaffected.
      */
-    public static TaskRunnable makeTask(String configString) throws JsonProcessingException, IOException {
+    public static TaskRunnable makeTask(String configString, CodecJackson defaultCodec)
+            throws JsonProcessingException, IOException {
         String subbedConfigString = subAt(configString);
         Config config = ConfigFactory.parseString(subbedConfigString,
                                                   ConfigParseOptions.defaults().setOriginDescription("job.conf"));
@@ -94,11 +99,11 @@ public class TaskRunner {
                                           .withFallback(ConfigFactory.load())
                                           .resolve();
             jobConfig = jobConfig.resolveWith(globalDefaults);
-            codec = Jackson.defaultCodec().withConfig(globalDefaults);
+            codec = defaultCodec.withConfig(globalDefaults);
         } else {
             jobConfig = jobConfig.resolve(ConfigResolveOptions.defaults().setAllowUnresolved(true))
                                  .resolveWith(ConfigFactory.load());
-            codec = Jackson.defaultCodec();
+            codec = defaultCodec;
         }
         return codec.decodeObject(TaskRunnable.class, jobConfig);
     }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/AbstractStreamFileDataSource.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/AbstractStreamFileDataSource.java
@@ -328,7 +328,6 @@ public abstract class AbstractStreamFileDataSource extends TaskDataSource implem
                 persistentStreamFileSource.init(getMarkDirFile(), shards);
             }
             if (filter != null) {
-                filter.open();
                 setSource(new StreamSourceFiltered(source, filter));
             }
             if (hash) {

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceFiltered.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceFiltered.java
@@ -78,9 +78,6 @@ public class DataSourceFiltered extends TaskDataSource {
 
     @Override
     public void init() {
-        if (filter != null) {
-            filter.open();
-        }
         stream.init();
     }
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/StreamTokenizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/StreamTokenizer.java
@@ -46,9 +46,6 @@ public class StreamTokenizer extends Tokenizer {
     @Override
     public Tokenizer initialize() {
         super.initialize();
-        if (filter != null) {
-            filter.open();
-        }
         return this;
     }
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/ColumnBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/ColumnBundleizer.java
@@ -40,9 +40,6 @@ public class ColumnBundleizer extends NewlineBundleizer {
     @Override
     public void open() {
         super.open();
-        if (tokenFilter != null) {
-            tokenFilter.open();
-        }
     }
 
     @Override

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/NewlineBundleizer.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/bundleizer/NewlineBundleizer.java
@@ -36,9 +36,6 @@ public abstract class NewlineBundleizer extends BundleizerFactory {
 
     @Override
     public void open() {
-        if (lineFilter != null) {
-            lineFilter.open();
-        }
     }
 
     @Override


### PR DESCRIPTION
also removes VFilter.acceptNull because it seems way preferable
to perform a few extra `if (value == null) { return null; }`
checks during a VFChain than to make people handle the otherwise
terribly confusing special casing involved.