### PR TITLE
Implement maximum over-estimation for top-K.

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/tree/concurrent/ConcurrentTreeNode.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/tree/concurrent/ConcurrentTreeNode.java
@@ -375,7 +375,7 @@ public class ConcurrentTreeNode extends AbstractTreeNode {
         return true;
     }
 
-    HashMap<String, TreeNodeData> createMap() {
+    public HashMap<String, TreeNodeData> createMap() {
         if (data == null) {
             data = new HashMap<>();
         }

--- a/hydra-data/src/main/java/com/addthis/hydra/data/util/KeyTopper.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/util/KeyTopper.java
@@ -63,6 +63,12 @@ public final class KeyTopper implements Codable, BytesCodable {
     @FieldConfig(codable = true)
     private boolean lossy;
 
+    /**
+     * Error estimates are only supported in the BytesCodable
+     * serialization format. They are not supported
+     * in the older serialization format to preserve
+     * serialization compatibility.
+     */
     @FieldConfig(codable = false)
     private HashMap<String, Long> errors;
 

--- a/hydra-data/src/test/java/com/addthis/hydra/data/util/TestKeyTopper.java
+++ b/hydra-data/src/test/java/com/addthis/hydra/data/util/TestKeyTopper.java
@@ -51,6 +51,29 @@ public class TestKeyTopper {
         assertEquals(new Long(2), topper2.get("b"));
         assertEquals(new Long(3), topper2.get("c"));
         assertEquals(new Long(4), topper2.get("d"));
+        assertNull(topper2.getError("a"));
+        assertNull(topper2.getError("b"));
+        assertNull(topper2.getError("c"));
+        assertNull(topper2.getError("d"));
+    }
+
+    @Test
+    public void encodeWithErrorEstimates() {
+        KeyTopper topper1 = new KeyTopper();
+        topper1.init().setLossy(true).enableErrors(true);
+        topper1.increment("a", 2);
+        topper1.increment("b", 2);
+        topper1.increment("c", 2);
+        topper1.increment("d", 2);
+        assertEquals(2, topper1.size());
+        byte[] serialized = topper1.bytesEncode(0);
+        KeyTopper topper2 = new KeyTopper();
+        topper2.bytesDecode(serialized, 0);
+        assertEquals(2, topper2.size());
+        assertEquals(new Long(2), topper2.get("c"));
+        assertEquals(new Long(2), topper2.get("d"));
+        assertEquals(new Long(1), topper2.getError("c"));
+        assertEquals(new Long(1), topper2.getError("d"));
     }
 
     @Test


### PR DESCRIPTION
This is an extension of https://github.com/addthis/hydra/pull/148. Added maximum over-estimation for top-K. Feature is optional and disabled by default. If enabled then each top-K item tracks the maximum over-estimation of its associated count. Query results will return this error as an entry in a map data attachment. Implemented option to query only gauranteed top-K items which is convenient. Documentation for top-K data attachment has been updated.