### PR TITLE
Added empty output aliased to FilteredDataOutput. Ref T53231

### DIFF
--- a/hydra-task/src/main/resources/reference.conf
+++ b/hydra-task/src/main/resources/reference.conf
@@ -86,6 +86,10 @@ plugins {
     ganglia: GangliaOutput
     http: DataOutputHttp
     tree: tree.TreeMapper
+    empty: { _class: filtered
+      filter: []
+      output: {tree {root:[{const:"EMPTY"}]}}
+    }
   }
 
   output-factory {


### PR DESCRIPTION
Instead of adding a new class, I opted for an alias to FilterDataOutput with empty chain filter and an empty tree output.

I wanted to use unary (true) in extra-filters, but that will require jobs to include extra-filters. An empty chain was the best thing I could come up with.