### PR TITLE
Writable directories job validation

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/job/web/resources/JobsResource.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/web/resources/JobsResource.java
@@ -821,8 +821,7 @@ public class JobsResource {
         String message = null;
         int lineNumber = 1;
         try {
-            TaskRunnable task = TaskRunner.makeTask(expandedConfig, validationCodec);
-            task.validateWritableRootPaths();
+            TaskRunner.makeTask(expandedConfig, validationCodec);
             return Response.ok(new JSONObject().put("result", "valid").toString()).build();
         } catch (ConfigException ex) {
             ConfigOrigin exceptionOrigin = ex.origin();

--- a/hydra-main/src/main/java/com/addthis/hydra/job/web/resources/JobsResource.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/web/resources/JobsResource.java
@@ -821,7 +821,8 @@ public class JobsResource {
         String message = null;
         int lineNumber = 1;
         try {
-            TaskRunner.makeTask(expandedConfig, validationCodec);
+            TaskRunnable task = TaskRunner.makeTask(expandedConfig, validationCodec);
+            task.validateWritableRootPaths();
             return Response.ok(new JSONObject().put("result", "valid").toString()).build();
         } catch (ConfigException ex) {
             ConfigOrigin exceptionOrigin = ex.origin();

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamMapper.java
@@ -13,6 +13,7 @@
  */
 package com.addthis.hydra.task.map;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.io.File;
@@ -20,11 +21,14 @@ import java.io.IOException;
 
 import java.net.ServerSocket;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 
+import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 
 import com.addthis.basis.jmx.MBeanRemotingSupport;
@@ -40,8 +44,11 @@ import com.addthis.hydra.task.run.TaskExitState;
 import com.addthis.hydra.task.run.TaskRunnable;
 import com.addthis.hydra.task.source.TaskDataSource;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Meter;
@@ -89,31 +96,37 @@ public class StreamMapper implements StreamEmitter, TaskRunnable {
     private static final Logger log = LoggerFactory.getLogger(StreamMapper.class);
 
     /** The data source for this job. */
-    @JsonProperty(required = true) private TaskDataSource source;
+    private final TaskDataSource source;
 
     /** The transformations to apply onto the data. */
-    @JsonProperty private MapDef map;
+    private final MapDef map;
 
     /** The data sink for emitting the result of the transformations. */
-    @JsonProperty(required = true) private TaskDataOutput output;
+    private final TaskDataOutput output;
 
     /**
      * Allow more flexible stream builders.  For example, asynchronous or builders
      * where one or more bundles roll up into a single bundle or a single bundle causes
      * the emission of multiple bundles.
      */
-    @JsonProperty private StreamBuilder builder;
+    private final StreamBuilder builder;
 
     /** Print to the console statistics while processing the data. Default is {@code true}. */
-    @JsonProperty private boolean stats;
+    private final boolean stats;
 
     /** How frequently statistics should be printed. */
-    @JsonProperty @Time(TimeUnit.NANOSECONDS) private long metricTick;
+    private final long metricTick;
 
-    @JsonProperty(required = true) private int threads;
-    @JsonProperty private boolean enableJmx;
-    @JsonProperty private boolean emitTaskState;
-    @JsonProperty private SimpleDateFormat dateFormat;
+    /**
+     * If true then ensure that writable directories are all unique.
+     * Default is true.
+     **/
+    private final boolean validateDirs;
+
+    private final int threads;
+    private final boolean enableJmx;
+    private final boolean emitTaskState;
+    private final SimpleDateFormat dateFormat;
 
     private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
 
@@ -133,6 +146,31 @@ public class StreamMapper implements StreamEmitter, TaskRunnable {
 
     private MBeanRemotingSupport jmxremote;
     private Thread feeder;
+
+    @JsonCreator
+    public StreamMapper(@JsonProperty(value = "source", required = true) TaskDataSource source,
+            @JsonProperty("map") MapDef map,
+            @JsonProperty(value = "output", required = true) TaskDataOutput output,
+            @JsonProperty("builder") StreamBuilder builder,
+            @JsonProperty("stats") boolean stats,
+            @JsonProperty("metricTick") @Time(TimeUnit.NANOSECONDS) long metricTick,
+            @JsonProperty(value = "threads", required = true) int threads,
+            @JsonProperty("enableJmx") boolean enableJmx,
+            @JsonProperty("emitTaskState") boolean emitTaskState,
+            @JsonProperty("dateFormat") SimpleDateFormat dateFormat,
+            @JsonProperty("validateDirs") boolean validateDirs) {
+        this.source = source;
+        this.map = map;
+        this.output = output;
+        this.builder = builder;
+        this.stats = stats;
+        this.metricTick = metricTick;
+        this.threads = threads;
+        this.enableJmx = enableJmx;
+        this.emitTaskState = emitTaskState;
+        this.dateFormat = dateFormat;
+        this.validateDirs = validateDirs;
+    }
 
     @Override
     public void start() {
@@ -370,8 +408,52 @@ public class StreamMapper implements StreamEmitter, TaskRunnable {
         }
     }
 
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return ImmutableList.<Path>builder()
+                            .addAll(source.writableRootPaths())
+                            .addAll(output.writableRootPaths())
+                            .build();
+    }
+
     public CompletableFuture<Void> getCompletionFuture() {
         return completionFuture;
+    }
+
+    @Override
+    public void validateWritableRootPaths() {
+        if (!validateDirs) {
+            return;
+        }
+        StringBuilder builder = new StringBuilder();
+        ImmutableList<Path> sources = source.writableRootPaths();
+        ImmutableList<Path> sinks = output.writableRootPaths();
+        Set<Path> sourcesSet = new HashSet<>();
+        Set<Path> sinksSet = new HashSet<>();
+        for (Path source : sources) {
+            if(!sourcesSet.add(source)) {
+                String message = String.format("The writable directory is used in more than one location " +
+                                               "in the input section: \"%s\"\n", source);
+                builder.append(message);
+            }
+        }
+        for (Path sink : sinks) {
+            if(!sinksSet.add(sink)) {
+                String message = String.format("The writable directory is used in more than one location " +
+                                               "in the output section: \"%s\"\n", sink);
+                builder.append(message);
+            }
+        }
+        Sets.SetView<Path> intersect = Sets.intersection(sourcesSet, sinksSet);
+        if (intersect.size() > 0) {
+            String message = String.format("The following one or more directories are used in both an input " +
+                                           "section and an output section: \"%s\"\n",
+                                           intersect.toString());
+            builder.append(message);
+        }
+        if (builder.length() > 0) {
+            throw new IllegalArgumentException(builder.toString());
+        }
     }
 
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamMapper.java
@@ -170,6 +170,7 @@ public class StreamMapper implements StreamEmitter, TaskRunnable {
         this.emitTaskState = emitTaskState;
         this.dateFormat = dateFormat;
         this.validateDirs = validateDirs;
+        validateWritableRootPaths();
     }
 
     @Override
@@ -420,7 +421,6 @@ public class StreamMapper implements StreamEmitter, TaskRunnable {
         return completionFuture;
     }
 
-    @Override
     public void validateWritableRootPaths() {
         if (!validateDirs) {
             return;

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractOutputWriter.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/AbstractOutputWriter.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
  * in the order in which the bundles are produced. The second strategy is enabled
  * by setting {@link #waitForDiskFlushThread} to true.
  */
-public abstract class AbstractOutputWriter {
+public abstract class AbstractOutputWriter implements WritableRootPaths {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractOutputWriter.class);
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/DataOutputFile.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/DataOutputFile.java
@@ -14,7 +14,14 @@
 package com.addthis.hydra.task.output;
 
 
+import javax.annotation.Nonnull;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import com.addthis.codec.annotations.FieldConfig;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * This output sink <span class="hydra-summary">shards the output stream to one or more files</span>.
@@ -93,4 +100,8 @@ public class DataOutputFile extends AbstractDataOutput {
         return writer;
     }
 
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return writer.writableRootPaths();
+    }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/DefaultOutputWrapperFactory.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/DefaultOutputWrapperFactory.java
@@ -13,6 +13,7 @@
  */
 package com.addthis.hydra.task.output;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.File;
@@ -21,6 +22,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import com.addthis.basis.io.IOWrap;
 import com.addthis.basis.util.Bytes;
@@ -30,6 +33,7 @@ import com.addthis.muxy.MuxFileDirectory;
 import com.addthis.muxy.MuxFileDirectoryCache;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -282,5 +286,10 @@ public class DefaultOutputWrapperFactory implements OutputWrapperFactory {
             return null;
         }
         return file;
+    }
+
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return ImmutableList.of(Paths.get(dir));
     }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputWrapperFactory.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputWrapperFactory.java
@@ -22,7 +22,7 @@ import com.addthis.codec.annotations.Pluggable;
  * Interface for classes capable of [re]opening {@link OutputWrapper}s.
  */
 @Pluggable("output-factory")
-public interface OutputWrapperFactory {
+public interface OutputWrapperFactory extends WritableRootPaths {
 
     /**
      * Open a new or reopen an existing {@link OutputWrapper} and return a reference to that object

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputWriter.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/OutputWriter.java
@@ -13,6 +13,8 @@
  */
 package com.addthis.hydra.task.output;
 
+import javax.annotation.Nonnull;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -24,11 +26,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import java.nio.file.Path;
+
 import com.addthis.basis.util.Bytes;
 import com.addthis.basis.util.Files;
 import com.addthis.basis.util.JitterClock;
 
 import com.addthis.codec.annotations.FieldConfig;
+
+import com.google.common.collect.ImmutableList;
 
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;
@@ -285,4 +291,10 @@ public class OutputWriter extends AbstractOutputWriter {
         this.maxOpen = maxOpen;
         return this;
     }
+
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return factory.writableRootPaths();
+    }
+
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/TaskDataOutput.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/TaskDataOutput.java
@@ -32,7 +32,7 @@ import com.addthis.codec.annotations.Pluggable;
  * @hydra-doc-position 5
  */
 @Pluggable("output-sink")
-public abstract class TaskDataOutput implements DataChannelOutput {
+public abstract class TaskDataOutput implements DataChannelOutput, WritableRootPaths {
 
     protected final BundleFormat format;
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/TaskDataOutputChain.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/TaskDataOutputChain.java
@@ -13,12 +13,19 @@
  */
 package com.addthis.hydra.task.output;
 
+import javax.annotation.Nonnull;
+
+import java.util.Arrays;
 import java.util.List;
+
+import java.nio.file.Path;
 
 import com.addthis.bundle.channel.DataChannelError;
 import com.addthis.bundle.core.Bundle;
 import com.addthis.bundle.core.Bundles;
 import com.addthis.codec.annotations.FieldConfig;
+
+import com.google.common.collect.ImmutableList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -126,4 +133,12 @@ public class TaskDataOutputChain extends DataOutputTypeList {
         }
         log.warn("[sourceError] forwarding complete");
     }
+
+
+    @Nonnull @Override public ImmutableList<Path> writableRootPaths() {
+        return ImmutableList.copyOf(
+                Arrays.stream(outputs).flatMap(
+                        output -> output.writableRootPaths().stream()).iterator());
+    }
+
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/WritableRootPaths.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/WritableRootPaths.java
@@ -11,26 +11,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.addthis.hydra.task.run;
+package com.addthis.hydra.task.output;
 
-import com.addthis.codec.annotations.Pluggable;
-import com.addthis.hydra.task.output.WritableRootPaths;
+import javax.annotation.Nonnull;
 
-/**
- * This is the specification for a Hydra job.
- *
- * @user-reference
- * @hydra-category Hydra Jobs
- * @hydra-doc-position 1
- */
-@Pluggable("task")
-public interface TaskRunnable extends AutoCloseable, WritableRootPaths {
+import java.nio.file.Path;
 
-    public abstract void start();
+import com.google.common.collect.ImmutableList;
+
+public interface WritableRootPaths {
 
     /**
-     * @throws IllegalArgumentException if output directories
-     * overlap.
+     * List of paths that will be written to.
      */
-    public default void validateWritableRootPaths() {}
+    public default @Nonnull ImmutableList<Path> writableRootPaths() {
+        return ImmutableList.of();
+    }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/tree/TreeMapper.java
@@ -13,6 +13,8 @@
  */
 package com.addthis.hydra.task.output.tree;
 
+import javax.annotation.Nonnull;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -57,6 +59,7 @@ import com.addthis.hydra.task.run.TaskRunConfig;
 import com.addthis.meshy.MeshyServer;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -591,5 +594,10 @@ public final class TreeMapper extends DataOutputTypeList implements Codable {
     @Override
     public void sourceError(Throwable err) {
         // TODO
+    }
+
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return ImmutableList.of(Paths.get(config.dir, directory));
     }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/pipeline/PipelineTask.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/pipeline/PipelineTask.java
@@ -72,7 +72,6 @@ public class PipelineTask implements TaskRunnable {
 
     /**
      * If true then ensure that writable directories are all unique.
-     * Default is true.
      **/
     private final boolean validateDirs;
 
@@ -99,6 +98,7 @@ public class PipelineTask implements TaskRunnable {
         }
         this.phaseComplete = complete.build();
         this.phaseNext = next.build();
+        validateWritableRootPaths();
     }
 
     @Override public void start() {
@@ -158,7 +158,6 @@ public class PipelineTask implements TaskRunnable {
                         phase -> phase.writableRootPaths().stream()).iterator());
     }
 
-    @Override
     public void validateWritableRootPaths() {
         if (!validateDirs) {
             return;

--- a/hydra-task/src/main/java/com/addthis/hydra/task/run/TaskRunnable.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/run/TaskRunnable.java
@@ -28,9 +28,4 @@ public interface TaskRunnable extends AutoCloseable, WritableRootPaths {
 
     public abstract void start();
 
-    /**
-     * @throws IllegalArgumentException if output directories
-     * overlap.
-     */
-    public default void validateWritableRootPaths() {}
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/AbstractDataSourceWrapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/AbstractDataSourceWrapper.java
@@ -13,9 +13,15 @@
  */
 package com.addthis.hydra.task.source;
 
+import javax.annotation.Nonnull;
+
+import java.nio.file.Path;
+
 import com.addthis.bundle.channel.DataChannelError;
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.annotations.FieldConfig;
+
+import com.google.common.collect.ImmutableList;
 
 
 public abstract class AbstractDataSourceWrapper extends TaskDataSource {
@@ -57,5 +63,10 @@ public abstract class AbstractDataSourceWrapper extends TaskDataSource {
     @Override
     public void close() {
         source.close();
+    }
+
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return source.writableRootPaths();
     }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/AbstractStreamFileDataSource.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/AbstractStreamFileDataSource.java
@@ -13,6 +13,7 @@
  */
 package com.addthis.hydra.task.source;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
 
@@ -34,6 +35,9 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import com.addthis.basis.io.IOWrap;
 import com.addthis.basis.util.Files;
@@ -62,6 +66,7 @@ import com.addthis.hydra.task.stream.StreamSourceFiltered;
 import com.addthis.hydra.task.stream.StreamSourceHashed;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -758,6 +763,11 @@ public abstract class AbstractStreamFileDataSource extends TaskDataSource implem
             }
             return null;
         }
+    }
+
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return ImmutableList.of(Paths.get(markDir));
     }
 
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/AggregateTaskDataSource.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/AggregateTaskDataSource.java
@@ -13,13 +13,20 @@
  */
 package com.addthis.hydra.task.source;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.NoSuchElementException;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.annotations.FieldConfig;
+
+import com.google.common.collect.ImmutableList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -162,4 +169,12 @@ public class AggregateTaskDataSource extends TaskDataSource {
         }
         return null;
     }
+
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return ImmutableList.copyOf(
+                Arrays.stream(sources).flatMap(
+                        output -> output.writableRootPaths().stream()).iterator());
+    }
+
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceFiltered.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceFiltered.java
@@ -13,11 +13,18 @@
  */
 package com.addthis.hydra.task.source;
 
+import javax.annotation.Nonnull;
+
+import java.util.Arrays;
 import java.util.NoSuchElementException;
+
+import java.nio.file.Path;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.hydra.data.filter.bundle.BundleFilter;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * This data source <span class="hydra-summary">applies a filter to an input source</span>.
@@ -109,5 +116,10 @@ public class DataSourceFiltered extends TaskDataSource {
         }
         peek = null;
         return ret;
+    }
+
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return stream.writableRootPaths();
     }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceHashed.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceHashed.java
@@ -13,12 +13,18 @@
  */
 package com.addthis.hydra.task.source;
 
+import javax.annotation.Nonnull;
+
 import java.util.NoSuchElementException;
+
+import java.nio.file.Path;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.hydra.common.hash.PluggableHashFunction;
 import com.addthis.hydra.task.run.TaskRunConfig;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * This data source <span class="hydra-summary">shards the input source by hashing on a bundle field</span>.
@@ -90,5 +96,10 @@ public class DataSourceHashed extends TaskDataSource {
         }
         peek = null;
         return ret;
+    }
+
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return stream.writableRootPaths();
     }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourcePrefetch.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourcePrefetch.java
@@ -13,10 +13,16 @@
  */
 package com.addthis.hydra.task.source;
 
+import javax.annotation.Nonnull;
+
 import java.util.LinkedList;
+
+import java.nio.file.Path;
 
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.annotations.FieldConfig;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * This {@link TaskDataSource source} <span class="hydra-summary">prefetches bundles from an underlying data source</span>.
@@ -72,5 +78,10 @@ public final class DataSourcePrefetch extends TaskDataSource {
     @Override
     public synchronized Bundle peek() {
         return prefetch() ? prefetch.getFirst() : null;
+    }
+
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return source.writableRootPaths();
     }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceRange.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceRange.java
@@ -13,9 +13,15 @@
  */
 package com.addthis.hydra.task.source;
 
+import javax.annotation.Nonnull;
+
+import java.nio.file.Path;
+
 import com.addthis.bundle.channel.DataChannelError;
 import com.addthis.bundle.core.Bundle;
 import com.addthis.codec.annotations.FieldConfig;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * This {@link TaskDataSource source} <span class="hydra-summary">retrieves a subset of an underlying data source</span>.
@@ -68,6 +74,11 @@ public class DataSourceRange extends TaskDataSource {
 
     @Override public void init() {
         source.init();
+    }
+
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return source.writableRootPaths();
     }
 
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceStreamList.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceStreamList.java
@@ -13,6 +13,8 @@
  */
 package com.addthis.hydra.task.source;
 
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -31,6 +33,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import com.addthis.basis.io.IOWrap;
 import com.addthis.basis.util.Strings;
 
@@ -45,6 +50,7 @@ import com.addthis.hydra.task.stream.StreamFile;
 import com.addthis.hydra.task.stream.StreamFileSource;
 import com.addthis.hydra.task.stream.StreamSourceHashed;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -579,5 +585,10 @@ public abstract class DataSourceStreamList extends TaskDataSource implements Sup
                 Thread.currentThread().interrupt();
             }
         }
+    }
+
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return ImmutableList.of(Paths.get(markDir));
     }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/SortedTaskDataSource.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/SortedTaskDataSource.java
@@ -13,8 +13,12 @@
  */
 package com.addthis.hydra.task.source;
 
+import javax.annotation.Nonnull;
+
 import java.util.Iterator;
 import java.util.TreeMap;
+
+import java.nio.file.Path;
 
 import com.addthis.bundle.channel.DataChannelError;
 import com.addthis.bundle.core.Bundle;
@@ -23,6 +27,8 @@ import com.addthis.bundle.core.BundleFormat;
 import com.addthis.bundle.value.ValueObject;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.hydra.task.util.BundleComparator;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * This {@link TaskDataSource source} <span class="hydra-summary">sorts an underlying data source</span>.
@@ -117,5 +123,10 @@ public class SortedTaskDataSource extends TaskDataSource {
     @Override
     public void close() {
         source.close();
+    }
+
+    @Nonnull @Override
+    public ImmutableList<Path> writableRootPaths() {
+        return source.writableRootPaths();
     }
 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/TaskDataSource.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/TaskDataSource.java
@@ -18,6 +18,7 @@ import com.addthis.bundle.core.BundleField;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.codec.annotations.Pluggable;
 import com.addthis.codec.codables.Codable;
+import com.addthis.hydra.task.output.WritableRootPaths;
 
 /**
  * This section of the job specification handles input sources.
@@ -30,7 +31,7 @@ import com.addthis.codec.codables.Codable;
  * @exclude-fields shardField, enabled
  */
 @Pluggable("input-source")
-public abstract class TaskDataSource implements Codable, DataChannelSource, Cloneable {
+public abstract class TaskDataSource implements Codable, DataChannelSource, Cloneable, WritableRootPaths {
 
     /**
      * Optionally specify a field that will be used as input to a

--- a/hydra-task/src/main/resources/reference.conf
+++ b/hydra-task/src/main/resources/reference.conf
@@ -32,7 +32,7 @@ com.addthis.hydra.task {
   hoover.Hoover.config: {}
   output.tree.TreeMapper.config: {}
   output.AbstractDataOutput.config: {}
-  pipeline.PipelineTask.validateDirs: true
+  pipeline.PipelineTask.validateDirs: false
   source.DataSourceStreamList.config: {}
   source.DataSourceHashed.config: {}
   source.AbstractStreamFileDataSource.config: {}
@@ -66,13 +66,20 @@ com.addthis.hydra.task.map.StreamMapper {
   enableJmx: true
   emitTaskState: true
   dateFormat: "yyMMdd-HHmmss"
-  validateDirs: true
+  validateDirs: false
   map {}
 
   threads: ${?task.threads}
   enableJmx: ${?split.minion.usejmx}
   emitTaskState: ${?task.mapper.emitState}
   dateFormat: ${?task.mapper.dateFormat}
+}
+
+hydra.validation {
+  com.addthis.hydra.task {
+    map.StreamMapper.validateDirs: true
+    pipeline.PipelineTask.validateDirs: true
+  }
 }
 
 plugins {

--- a/hydra-task/src/main/resources/reference.conf
+++ b/hydra-task/src/main/resources/reference.conf
@@ -32,6 +32,7 @@ com.addthis.hydra.task {
   hoover.Hoover.config: {}
   output.tree.TreeMapper.config: {}
   output.AbstractDataOutput.config: {}
+  pipeline.PipelineTask.validateDirs: true
   source.DataSourceStreamList.config: {}
   source.DataSourceHashed.config: {}
   source.AbstractStreamFileDataSource.config: {}
@@ -65,6 +66,7 @@ com.addthis.hydra.task.map.StreamMapper {
   enableJmx: true
   emitTaskState: true
   dateFormat: "yyMMdd-HHmmss"
+  validateDirs: true
   map {}
 
   threads: ${?task.threads}


### PR DESCRIPTION
Adds a step during job validation that checks if the two or more directories that will be created (mark directory, tree directory, split directory, etc) have the same path. Validates StreamMapper and PipelineTask jobs. Notable improvements since the previous version of this pull request is that validation no longer happens during constructor making it possible to save the job configuration. Default methods have been used to simplify implementation. Enabled by default can be disabled by setting validateDirs to false.