### PR TITLE
Hydra job query input source.

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/query/source/QueryEngineSource.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/query/source/QueryEngineSource.java
@@ -11,9 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.addthis.hydra.query;
+package com.addthis.hydra.data.query.source;
 
-import java.util.concurrent.Semaphore;
+import java.io.Closeable;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.addthis.basis.util.Parameter;
 
@@ -21,8 +27,8 @@ import com.addthis.bundle.channel.DataChannelOutput;
 import com.addthis.hydra.data.query.Query;
 import com.addthis.hydra.data.query.QueryException;
 import com.addthis.hydra.data.query.engine.QueryEngine;
-import com.addthis.hydra.data.query.source.QueryHandle;
-import com.addthis.hydra.data.query.source.QuerySource;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Gauge;
@@ -35,47 +41,60 @@ import io.netty.channel.DefaultChannelProgressivePromise;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /** */
-public abstract class QueryEngineSource implements QuerySource {
+public abstract class QueryEngineSource implements QuerySource, Closeable {
 
     private static final int maxConcurrency = Parameter.intValue("query.engine.source.maxConcurrency", 4);
 
     private final Logger log = LoggerFactory.getLogger(QueryEngineSource.class);
-    private final Semaphore engineGate = new Semaphore(maxConcurrency);
 
-    private final Gauge<Integer> engineGatePermitMetric = Metrics.newGauge(QueryEngineSource.class, "engineGatePermitMetric", new Gauge<Integer>() {
+    @SuppressWarnings("unused")
+    private final Gauge<Integer> engineGatePermitMetric = Metrics.newGauge(QueryEngineSource.class,
+                                                                           "engineGatePermitMetric",
+                                                                           new Gauge<Integer>() {
         @Override
         public Integer value() {
-            return engineGate.availablePermits();
+            return (maxConcurrency - executor.getActiveCount());
         }
     });
+
     private final Histogram engineGateHistogram = Metrics.newHistogram(QueryEngineSource.class, "engineGateHistogram");
+
+    private final ThreadPoolExecutor executor = new ThreadPoolExecutor(maxConcurrency, maxConcurrency,
+                                                                       0L, TimeUnit.MILLISECONDS,
+                                                                       new LinkedBlockingQueue<>(),
+                                                                       new ThreadFactoryBuilder()
+                                                                               .setNameFormat("QueryEngineSource-%d")
+                                                                               .setDaemon(true)
+                                                                               .build());
+
+    private final AtomicBoolean closed = new AtomicBoolean();
 
     @Override
     public QueryHandle query(final Query query, final DataChannelOutput consumer) throws QueryException {
-        return new Handle(query, consumer);
+        Handle result = new Handle(query, consumer);
+        result.setFuture(executor.submit(result));
+        return result;
     }
 
     public abstract QueryEngine getEngineLease();
 
     /** */
-    private class Handle extends Thread implements QueryHandle {
+    public class Handle implements Runnable, QueryHandle {
 
-        private Query query;
-        private QueryEngine engine;
-        private DataChannelOutput consumer;
+        private final Query query;
+        private final DataChannelOutput consumer;
+        private Future<?> future;
 
         Handle(Query query, DataChannelOutput consumer) {
-            setName("EngineSource " + query.uuid());
             this.query = query;
             this.consumer = consumer;
-            start();
         }
 
-        @Override public void run() {
-            engine = null;
+        @Override
+        public void run() {
+            QueryEngine engine = null;
             try {
-                engineGate.acquire(1);
-                engineGateHistogram.update(engineGate.availablePermits());
+                engineGateHistogram.update(maxConcurrency - executor.getActiveCount());
                 engine = getEngineLease();
                 engine.search(query, consumer,
                         new DefaultChannelProgressivePromise(null, ImmediateEventExecutor.INSTANCE));
@@ -87,24 +106,27 @@ public abstract class QueryEngineSource implements QuerySource {
                 log.warn("query error " + query.uuid() + " " + e + " " + consumer, e);
                 consumer.sourceError(new QueryException(e));
             } finally {
-                engineGate.release();
-                engineGateHistogram.update(engineGate.availablePermits());
+                engineGateHistogram.update(maxConcurrency - executor.getActiveCount());
                 if (engine != null) {
                     try {
                         engine.release();
                     } catch (Throwable t) {
                         log.warn("[dispatch] error during db release of " + engine + " : " + t, t);
-                        }
+                    }
                 }
             }
         }
 
         @Override
         public void cancel(String message) {
-            log.warn(query.uuid() + " cancel called on handle " + consumer + " message: " + message);
-            if (engine != null) {
-                interrupt();
+            if (future != null) {
+                log.warn(query.uuid() + " cancel called on handle " + consumer + " message: " + message);
+                future.cancel(true);
             }
+        }
+
+        void setFuture(Future<?> future) {
+            this.future = future;
         }
     }
 
@@ -114,6 +136,13 @@ public abstract class QueryEngineSource implements QuerySource {
 
     @Override
     public boolean isClosed() {
-        return false;
+        return closed.get();
+    }
+
+    @Override
+    public void close() {
+        if(!closed.getAndSet(true)) {
+            executor.shutdownNow();
+        }
     }
 }

--- a/hydra-data/src/main/java/com/addthis/hydra/data/query/source/QueryEngineSourceSingle.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/query/source/QueryEngineSourceSingle.java
@@ -11,9 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.addthis.hydra.query;
+package com.addthis.hydra.data.query.source;
 
 import com.addthis.hydra.data.query.engine.QueryEngine;
+import com.addthis.hydra.data.query.source.QueryEngineSource;
 import com.addthis.hydra.data.tree.DataTree;
 
 

--- a/hydra-main/src/main/java/com/addthis/hydra/query/util/QueryChannelUtil.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/query/util/QueryChannelUtil.java
@@ -35,9 +35,9 @@ import com.addthis.hydra.data.channel.BlockingNullConsumer;
 import com.addthis.hydra.data.query.Query;
 import com.addthis.hydra.data.query.QueryOpProcessor;
 import com.addthis.hydra.data.query.engine.QueryEngine;
+import com.addthis.hydra.data.query.source.QueryEngineSource;
 import com.addthis.hydra.data.query.source.QuerySource;
 import com.addthis.hydra.data.tree.ReadTree;
-import com.addthis.hydra.query.QueryEngineSource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/AbstractStreamDataSource.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/AbstractStreamDataSource.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.task.source;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.addthis.bundle.channel.DataChannelError;
+import com.addthis.bundle.core.Bundle;
+import com.addthis.bundle.core.BundleFactory;
+import com.addthis.codec.annotations.Time;
+
+import com.google.common.base.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.Timer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Throwables.propagate;
+import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
+
+/**
+ * Abstract implementation of TaskDataSource
+ * <p/>
+ * There are many common features that streaming data source needs to deal with
+ * and this class performs those tasks so that subclasses can leverage the common
+ * functionality.
+ * <p/>
+ */
+public abstract class AbstractStreamDataSource extends TaskDataSource implements BundleFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractStreamDataSource.class);
+
+    /**
+     * Maximum size of the queue that stores bundles prior to their processing.
+     * Default is either "dataSourceMeshy2.buffer" configuration value or 128.
+     */
+    @JsonProperty(required = true) protected int buffer;
+
+    @Time(TimeUnit.MILLISECONDS)
+    @JsonProperty protected int pollInterval;
+
+    @JsonProperty protected int pollCountdown;
+
+    /** Enable metrics visible only from jmx */
+    @JsonProperty protected boolean jmxMetrics;
+
+    /* metrics */
+    protected final Histogram fileSizeHisto = Metrics.newHistogram(getClass(), "fileSizeHisto");
+    protected final Timer readTimer = Metrics.newTimer(getClass(), "readTimer", TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
+    protected final Counter openNew = Metrics.newCounter(getClass(), "openNew");
+    protected final Counter openIndex = Metrics.newCounter(getClass(), "openIndex");
+    protected final Counter openSkip = Metrics.newCounter(getClass(), "openSkip");
+    protected final Counter skipping = Metrics.newCounter(getClass(), "skipping");
+    protected final Counter reading = Metrics.newCounter(getClass(), "reading");
+    protected final Counter opening = Metrics.newCounter(getClass(), "opening");
+    protected final Counter globalBundleSkip = Metrics.newCounter(getClass(), "globalBundleSkip");
+
+    // State control
+    protected final AtomicBoolean shuttingDown = new AtomicBoolean(false);
+    protected final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+    protected final CountDownLatch initialized = new CountDownLatch(1);
+    protected boolean localInitialized = false;
+
+    protected BlockingQueue<Bundle> queue;
+
+    @Override public void init() {
+        queue = new LinkedBlockingQueue<>(buffer);
+    }
+
+    @Nullable @Override public Bundle next() throws DataChannelError {
+        int countdown = pollCountdown;
+        while (((localInitialized || waitForInitialized()) && (pollCountdown == 0)) || (countdown-- > 0)) {
+            long startTime = jmxMetrics ? System.currentTimeMillis() : 0;
+            Bundle next = pollAndCloseOnInterrupt(pollInterval, TimeUnit.MILLISECONDS);
+            if (jmxMetrics) {
+                readTimer.update(System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS);
+            }
+            if (next != null) {
+                return next;
+            }
+            if (closeFuture.isDone()) {
+                closeFuture.join();
+                return null;
+            }
+            if (pollCountdown > 0) {
+                log.info("next polled null, retrying {} more times. shuttingDown={}", countdown, shuttingDown.get());
+            }
+            log.info(fileStatsToString("null poll "));
+        }
+        if (countdown < 0) {
+            log.info("exit with no data during poll countdown");
+        }
+        return null;
+    }
+
+    private Bundle pollAndCloseOnInterrupt(long pollFor, TimeUnit unit) {
+        boolean interrupted = false;
+        try {
+            long remainingNanos = unit.toNanos(pollFor);
+            long end = System.nanoTime() + remainingNanos;
+            while (true) {
+                try {
+                    return queue.poll(remainingNanos, TimeUnit.NANOSECONDS);
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    log.info("interrupted while polling for bundles; closing source then resuming poll");
+                    close();
+                    remainingNanos = end - System.nanoTime();
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Override public String toString() {
+        return populateToString(Objects.toStringHelper(this));
+    }
+
+    protected String fileStatsToString(String reason) {
+        return populateToString(Objects.toStringHelper(reason));
+    }
+
+    private String populateToString(Objects.ToStringHelper helper) {
+        return helper.add("reading", reading.count())
+                     .add("opening", opening.count())
+                     .add("unseen", openNew.count())
+                     .add("continued", openIndex.count())
+                     .add("skipping", skipping.count())
+                     .add("skipped", openSkip.count())
+                     .add("bundles-skipped", globalBundleSkip.count())
+                     .add("median-size", fileSizeHisto.getSnapshot().getMedian())
+                     .toString();
+    }
+
+    @Nullable @Override public Bundle peek() throws DataChannelError {
+        if (localInitialized || waitForInitialized()) {
+            try {
+                return queue.peek();
+            } catch (Exception ex) {
+                throw propagate(ex);
+            }
+        }
+        return null;
+    }
+
+    private boolean waitForInitialized() {
+        boolean wasInterrupted = false;
+        try {
+            while (!localInitialized
+                   && !awaitUninterruptibly(initialized, 3, TimeUnit.SECONDS)
+                   && !shuttingDown.get()) {
+                log.info(fileStatsToString("waiting for initialization"));
+                if (Thread.interrupted()) {
+                    wasInterrupted = true;
+                    log.info("interrupted while waiting for initialization; closing source then resuming wait");
+                    close();
+                }
+            }
+            log.info(fileStatsToString("initialized"));
+            localInitialized = true;
+            return true;
+        } finally {
+            if (wasInterrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+}

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceQuery.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/DataSourceQuery.java
@@ -1,0 +1,358 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.task.source;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import java.nio.file.Paths;
+
+import com.addthis.basis.util.LessFiles;
+import com.addthis.basis.util.Parameter;
+
+import com.addthis.bundle.channel.DataChannelOutput;
+import com.addthis.bundle.core.Bundle;
+import com.addthis.bundle.core.BundleField;
+import com.addthis.bundle.core.BundleFormat;
+import com.addthis.bundle.core.list.ListBundleFormat;
+import com.addthis.bundle.util.AutoField;
+import com.addthis.codec.json.CodecJSON;
+import com.addthis.hydra.data.query.FramedDataChannelReader;
+import com.addthis.hydra.data.query.Query;
+import com.addthis.hydra.data.query.QueryOpProcessor;
+import com.addthis.hydra.data.query.source.QueryEngineSourceSingle;
+import com.addthis.hydra.data.query.source.QueryHandle;
+import com.addthis.hydra.data.tree.ReadTree;
+import com.addthis.hydra.task.run.TaskRunConfig;
+import com.addthis.meshy.MeshyClient;
+import com.addthis.meshy.service.file.FileReference;
+import com.addthis.meshy.service.file.FileSource;
+import com.addthis.meshy.service.stream.StreamSource;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Throwables;
+import com.google.common.collect.FluentIterable;
+import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataSourceQuery extends AbstractStreamDataSource implements DataChannelOutput {
+
+    public static final int FRAME_READER_POLL = Parameter.intValue("meshSourceAggregator.frameReader.poll", 0);
+
+    private final ExecutorService workerThreadPool = Executors.newFixedThreadPool(1,
+            new ThreadFactoryBuilder().setNameFormat("dataSourceQuery-%d").build());
+
+    private static final Logger log = LoggerFactory.getLogger(DataSourceQuery.class);
+
+    private final BundleFormat formatIn = new ListBundleFormat();
+
+    private final BundleFormat formatOut = new ListBundleFormat();
+
+    /**
+     * The tree job that is to be queried. Specify no jobId
+     * for a job to query itself. This field is optional.
+     */
+    @JsonProperty private String jobId;
+
+    /**
+     * Optionally specify the directory
+     * of the tree for the given job. Default
+     * is "data".
+     */
+    @JsonProperty(required = true) private String treeDir;
+
+    /**
+     * Path for the query. This field is required.
+     */
+    @JsonProperty(required = true) private String path;
+
+    /**
+     * Operations for the query. This field is optional.
+     */
+    @JsonProperty private String ops;
+
+    /**
+     * Which tasks to query. This field is optional.
+     */
+    @JsonProperty private int[] tasks;
+
+    /** Number of tasks in the query job. This field is required. */
+    @JsonProperty(required = true) private int taskTotal;
+
+    /**
+     * Optionally specify the field names for the columns
+     * produced by the query. Otherwise the fields will
+     * be named "0", "1", "2", etc. Default is null.
+     */
+    @JsonProperty private AutoField[] fields;
+
+    @JsonProperty private TaskRunConfig config;
+
+    /**
+     * Hostname of the query system mesh network. Default is 'localhost'
+     */
+    @JsonProperty
+    private String queryHost;
+
+    /**
+     * Port number of the query system mesh network. Default is
+     * value of system property 'qmaster.mesh.port'.
+     */
+    @JsonProperty private int queryPort;
+
+    private final AtomicReference<Throwable> firstError = new AtomicReference<>();
+
+    private QueryEngineSourceSingle queryEngine;
+
+    private QueryHandle queryHandle;
+
+    CompletableFuture<Void> workerFuture;
+
+    private File tempDir;
+
+    private MeshyClient meshClient;
+
+    private boolean localInputSource;
+
+    private static String getFileMatchString(String job, String treeDir, String task) {
+        return "*/" + job + "/" + task + "/gold/" + treeDir + "/query";
+    }
+
+    private static Joiner COMMA_JOINER = Joiner.on(',');
+
+    private static String printTasks(int[] tasks) {
+        String result = "{";
+        result += COMMA_JOINER.join(Ints.asList(tasks));
+        result += "}";
+        return result;
+    }
+
+    @Override public void init() {
+        super.init();
+        localInputSource = (jobId == null);
+        try {
+            if (localInputSource) {
+                File dir = Paths.get(treeDir).toFile();
+                tempDir = LessFiles.createTempDir();
+                queryEngine = new QueryEngineSourceSingle(new ReadTree(dir));
+                Query query = new Query(config.jobId, new String[]{path}, null);
+                QueryOpProcessor proc = new QueryOpProcessor.Builder(this, new String[]{ops})
+                        .tempDir(tempDir).build();
+                queryHandle = queryEngine.query(query, proc);
+                initialized.countDown();
+                localInitialized = true;
+            } else {
+                if (tasks != null) {
+                    List<Integer> outBounds = Ints.asList(tasks).stream().filter(
+                            (x) -> ((x < 0) || (x >= taskTotal))).collect(Collectors.toList());
+                    if (outBounds.size() > 0) {
+                        throw new IllegalArgumentException("The following provided task numbers " +
+                                                           "are out of bounds: " + outBounds);
+                    }
+                } else {
+                    List<Integer> taskList = new ArrayList<>();
+                    int current = config.node;
+                    while (current < taskTotal) {
+                        taskList.add(current);
+                        current += config.nodeCount;
+                    }
+                    tasks = Ints.toArray(taskList);
+                }
+                Query query = new Query(config.jobId, new String[]{path}, new String[]{ops});
+                Map queryOptions = new HashMap<>();
+                queryOptions.put("query", CodecJSON.encodeString(query));
+                meshClient = new MeshyClient(queryHost, queryPort);
+                String meshFilePath = getFileMatchString(jobId, treeDir, printTasks(tasks));
+                FileSource source = new FileSource(meshClient);
+                source.requestRemoteFiles(meshFilePath);
+                source.waitComplete();
+                // collapse replicas of a file reference
+                Collection<FileReference> fileReferences = source.getFileMap().values();
+                log.info("Queries will run against {}", fileReferences.toString());
+                Runnable sourceWorker = new SourceWorker(fileReferences.iterator(), queryOptions);
+                workerFuture = CompletableFuture.runAsync(sourceWorker, workerThreadPool).whenComplete(
+                        (ignored, error) -> {
+                            if (error != null) {
+                                shuttingDown.set(true);
+                                closeFuture.completeExceptionally(error);
+                            }
+                        });
+                workerFuture.thenRunAsync(this::close);
+            }
+        } catch (Exception ex) {
+            throw Throwables.propagate(ex);
+        }
+    }
+
+    private<T> void cleanupResource(T target, Consumer<T> operation, String errorMessage) {
+        try {
+            if (target != null) {
+                operation.accept(target);
+            }
+        } catch (Exception ex) {
+            firstError.compareAndSet(null, ex);
+            log.error(errorMessage, ex);
+        }
+    }
+
+    @Override public void close() {
+        if (shuttingDown.compareAndSet(false, true)) {
+            cleanupResource(queryHandle, (x) -> x.cancel("closing query input source"),
+                            "Error attempting to cancel local query");
+            cleanupResource(queryEngine, (x) -> x.close(), "Error attempting to close local query engine");
+            cleanupResource(tempDir, (x) -> LessFiles.deleteDir(x), "Error attempting to delete local temporary directory");
+            cleanupResource(meshClient, (x) -> x.close(), "Error attempting to close mesh link");
+            cleanupResource(workerThreadPool, (x) -> x.shutdown(), "Error attempting to shutdown worker thread pool");
+            Throwable error = firstError.get();
+            if (error != null) {
+                closeFuture.completeExceptionally(error);
+                throw Throwables.propagate(error);
+            } else {
+                closeFuture.complete(null);
+            }
+        } else {
+            closeFuture.join();
+        }
+    }
+
+    private static String[] fieldNames(Bundle bundle) {
+        return FluentIterable.from(bundle.getFormat()).transform((field) -> field.getName()).toArray(String.class);
+    }
+
+    @Override public void send(Bundle input) {
+        try {
+            Bundle output;
+            if (fields == null) {
+                output = input;
+            } else {
+                if (fields.length != input.getFormat().getFieldCount()) {
+                    throw new IllegalStateException("Expecting " + fields.length + " fields " +
+                                                    Arrays.toString(fields) + " and result from query has " +
+                                                    input.getFormat().getFieldCount() + " fields " +
+                                                    Arrays.toString(fieldNames(input)));
+                }
+                output = formatOut.createBundle();
+                Iterator<BundleField> fieldsIn = input.getFormat().iterator();
+                for (int i = 0; i < fields.length; i++) {
+                    AutoField fieldOut = fields[i];
+                    fieldOut.setValue(output, input.getValue(fieldsIn.next()));
+                }
+            }
+            queue.put(output);
+        } catch (Exception ex) {
+            firstError.compareAndSet(null, ex);
+            close();
+        }
+    }
+
+    @Override public void send(List<Bundle> list) {
+        list.forEach(this::send);
+    }
+
+    @Override public void sendComplete() {
+        close();
+    }
+
+    @Override public void sourceError(Throwable throwable) {
+        firstError.compareAndSet(null, throwable);
+        close();
+    }
+
+    @Override public Bundle createBundle() {
+        return formatIn.createBundle();
+    }
+
+    private class SourceWorker implements Runnable {
+
+        private final Iterator<FileReference> fileReferences;
+
+        private final Map<String, String> queryOptions;
+
+        private FramedDataChannelReader dataChannel;
+
+        SourceWorker(Iterator<FileReference> fileReferences, Map<String,String> queryOptions) {
+            this.fileReferences = fileReferences;
+            this.queryOptions = queryOptions;
+        }
+
+        @Override public void run() {
+            try {
+                while (!shuttingDown.get()) {
+                    if (readChannel()) return;
+                }
+            } catch (Exception ex) {
+                log.warn("Exception while running data source query worker thread.", ex);
+                Throwables.propagate(ex);
+            } finally {
+                if (dataChannel != null) {
+                    try {
+                        dataChannel.close();
+                    } catch (IOException ex) {
+                        log.info("IO error trying to close data channel", ex);
+                    }
+                }
+            }
+        }
+
+        private boolean readChannel() throws Exception {
+            if (dataChannel == null) {
+                if (fileReferences.hasNext()) {
+                    FileReference reference = fileReferences.next();
+                    StreamSource streamSource = meshClient.getFileSource(reference.getHostUUID(),
+                                                                         reference.name,
+                                                                         queryOptions);
+                    dataChannel = new FramedDataChannelReader(streamSource, FRAME_READER_POLL);
+                } else {
+                    close();
+                    return true;
+                }
+            }
+            Bundle next = dataChannel.read();
+            if (next != null) {
+                while (!queue.offer(next, 1, TimeUnit.SECONDS)) {
+                    if (shuttingDown.get()) {
+                        return true;
+                    }
+                }
+                if (!localInitialized) {
+                    initialized.countDown();
+                    localInitialized = true;
+                }
+            } else if (dataChannel.isClosed()) {
+                dataChannel = null;
+            }
+            return false;
+        }
+    }
+}

--- a/hydra-task/src/main/resources/hydra-sources.conf
+++ b/hydra-task/src/main/resources/hydra-sources.conf
@@ -15,6 +15,7 @@ plugins {
       markDir: marks
     }
     prefetch: DataSourcePrefetch
+    query: DataSourceQuery
     range: DataSourceRange
     sorted: SortedTaskDataSource
   }
@@ -49,16 +50,18 @@ com.addthis.hydra.task {
   }
 
   source {
+    AbstractStreamDataSource {
+      buffer: 128
+      pollInterval: 1 second
+      pollCountdown: 1800
+    }
     AbstractStreamFileDataSource {
       magicMarksNumber: 42
       workers: 2
-      buffer: 128
       skipSourceExit: 0
       multiBundleReads: 1
       preOpen: 1
       format: {channel {}}
-      pollInterval: 1 second
-      pollCountdown: 1800
       latchTimeout: 30 seconds
 
       # support legacy system property paths for now
@@ -75,6 +78,13 @@ com.addthis.hydra.task {
       data: {}
       format: {gson {}}
       params: {}
+    }
+    DataSourceQuery {
+      config: {}
+      queryHost: "localhost"
+      queryPort = -1
+      queryPort = ${?qmaster.mesh.port}
+      treeDir: "data"
     }
   }
 }


### PR DESCRIPTION
Input source will either use the mqworkers to run a query
or run the query directly if no job identifier is provided.
Spawn or mqmaster are not used when running queries only the
mqworker network.

Refactors the AbstractStreamFileDataSource to extract the
functionality for streaming data sources into AbstractStreamDataSource.

At present no type of mark directory is implemented for the
query input source until we determine what is appropriate
for this input source.

Ref T53270. Ref T53475.