### PR TITLE
POC for better work stealing in MapFeeder. Ref T53505

### DIFF
--- a/hydra-main-api/src/main/java/com/addthis/hydra/task/source/TaskDataSource.java
+++ b/hydra-main-api/src/main/java/com/addthis/hydra/task/source/TaskDataSource.java
@@ -14,7 +14,6 @@
 package com.addthis.hydra.task.source;
 
 import com.addthis.bundle.channel.DataChannelSource;
-import com.addthis.bundle.core.BundleField;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.codec.annotations.Pluggable;
 import com.addthis.codec.codables.Codable;
@@ -38,7 +37,7 @@ public abstract class TaskDataSource implements Codable, DataChannelSource, Clon
      * hash function to determine which input processing thread to use. Default is null.
      */
     @FieldConfig(codable = true)
-    private BundleField shardField;
+    private String shardField;
 
     /** If false then disable this data source. Default is true. */
     @FieldConfig(codable = true)
@@ -46,7 +45,7 @@ public abstract class TaskDataSource implements Codable, DataChannelSource, Clon
 
     public abstract void init();
 
-    public final BundleField getShardField() {
+    public final String getShardField() {
         return shardField;
     }
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamMapper.java
@@ -146,6 +146,7 @@ public class StreamMapper implements StreamEmitter, TaskRunnable {
 
     private MBeanRemotingSupport jmxremote;
     private Thread feeder;
+    private volatile boolean closing;
 
     @JsonCreator
     public StreamMapper(@JsonProperty(value = "source", required = true) TaskDataSource source,
@@ -338,8 +339,12 @@ public class StreamMapper implements StreamEmitter, TaskRunnable {
 
     @Override
     public void close() throws InterruptedException {
-        feeder.interrupt();
+        closing = true;
         feeder.join();
+    }
+
+    public boolean isClosing() {
+        return closing;
     }
 
     /** called on process exit */


### PR DESCRIPTION
This is a proof of concept of using interrupt to notify main map feeder thread of hungry worker threads. When a worker thread drained its queue, it interrupts the main thread, which then batch fill all the drained queues before switching back to the normal round-robin-like dispatching.

It appears to work well in the case of one worker thread progressing much slower than the other, which is the main use case for this optimization. In the general case where filtering and output are slower than source, the code should have very low to no overhead. However, in the case of source being the bottleneck, the worker threads will interrupt the map feeder thread a lot for no benefit. Suggestions on how to improve that is welcome. There are other lesser optimizations to do, e.g. preventing too many interrupted exceptions etc. but I want to get some feedback on the general approach before fine tuning.

Also I repurposed existing "task.worksteal" parameter for this, assuming the current work stealing implementation isn't being used. If that's not the case, it can be easily changed to a new parameter.