### PR TITLE
Query notation for specifying a default value.

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/query/QueryElementNode.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/query/QueryElementNode.java
@@ -38,6 +38,7 @@ import com.addthis.hydra.data.tree.ReadTreeNode;
 import com.addthis.hydra.data.tree.TreeNodeData;
 import com.addthis.hydra.data.tree.prop.VirtualTreeNode;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
 
@@ -205,7 +206,8 @@ public class QueryElementNode implements Codable {
      * the input token. Optionally "+[text|hits]" can be used to set
      * the number of hits on the default node.
      */
-    private String extractDefaultValue(String tok) {
+    @VisibleForTesting
+    String extractDefaultValue(String tok) {
         int startDefault = -1;
         if (tok.startsWith(DEFAULT_NODE)) {
             startDefault = DEFAULT_NODE.length();
@@ -221,6 +223,8 @@ public class QueryElementNode implements Codable {
             } else {
                 defaultValue = tok.substring(startDefault, endDefault);
             }
+            // tok must either start with "+[" or "+%[" to have
+            // reached this line
             if (tok.startsWith(DEFAULT_NODE)) {
                 tok = "+" + tok.substring(endDefault + 1);
             } else if (tok.startsWith(DEFAULT_ATTACHMENT)) {

--- a/hydra-data/src/test/java/com/addthis/hydra/data/query/TestQueryElementNode.java
+++ b/hydra-data/src/test/java/com/addthis/hydra/data/query/TestQueryElementNode.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.data.query;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestQueryElementNode {
+
+    @Test
+    public void extractDefaultValue() {
+        QueryElementNode node = new QueryElementNode();
+        String output = node.extractDefaultValue("+");
+        assertEquals("+", output);
+        assertEquals(null, node.defaultValue);
+        assertEquals(0, node.defaultHits);
+        node = new QueryElementNode();
+        output = node.extractDefaultValue("+[abc]");
+        assertEquals("+", output);
+        assertEquals("abc", node.defaultValue);
+        assertEquals(0, node.defaultHits);
+        node = new QueryElementNode();
+        output = node.extractDefaultValue("+%[abc]foo=bar");
+        assertEquals("+%foo=bar", output);
+        assertEquals("abc", node.defaultValue);
+        assertEquals(0, node.defaultHits);
+        node = new QueryElementNode();
+        output = node.extractDefaultValue("+[abc]d,e,f");
+        assertEquals("+d,e,f", output);
+        assertEquals("abc", node.defaultValue);
+        assertEquals(0, node.defaultHits);
+        node = new QueryElementNode();
+        output = node.extractDefaultValue("+[abc|15]d,e,f");
+        assertEquals("+d,e,f", output);
+        assertEquals("abc", node.defaultValue);
+        assertEquals(15, node.defaultHits);
+    }
+}


### PR DESCRIPTION
There was a feature request to implement regular expression type
matching in the query path syntax for repeated expressions of
type X{n}, X{n,}, X{n,m}. This is a simpler form of that feature.
It implements a query path notation of the form "/+[foo]" or
"/+[foo]a,b,c". The string enclosed in the square brackets is a
default value that is returned when no matches are found. The
same notation works for the data attachment queries "/+%[foo]name=parameters"

There are several benefits to this approach. It is simpler
than the original request and was implemented quickly. It has
a more straightforward semantics in the sense that it ensures that
a column is always generated for the "+" request. It was unclear
whether there would be rows with variable-length columns in the
original X{n,m} request. It also meets the use case of the original
feature request.

Ref T52644.