### PR TITLE
Added MapFeederForkJoin and a StreamMapper flag to use it. Ref T53505

### DIFF
--- a/hydra-main-api/src/main/java/com/addthis/hydra/task/source/TaskDataSource.java
+++ b/hydra-main-api/src/main/java/com/addthis/hydra/task/source/TaskDataSource.java
@@ -14,7 +14,7 @@
 package com.addthis.hydra.task.source;
 
 import com.addthis.bundle.channel.DataChannelSource;
-import com.addthis.bundle.core.BundleField;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.codec.annotations.Pluggable;
 import com.addthis.codec.codables.Codable;
@@ -38,7 +38,7 @@ public abstract class TaskDataSource implements Codable, DataChannelSource, Clon
      * hash function to determine which input processing thread to use. Default is null.
      */
     @FieldConfig(codable = true)
-    private BundleField shardField;
+    private AutoField shardField;
 
     /** If false then disable this data source. Default is true. */
     @FieldConfig(codable = true)
@@ -46,7 +46,7 @@ public abstract class TaskDataSource implements Codable, DataChannelSource, Clon
 
     public abstract void init();
 
-    public final BundleField getShardField() {
+    public final AutoField getShardField() {
         return shardField;
     }
 

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/MapFeeder.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/MapFeeder.java
@@ -24,12 +24,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import java.text.DecimalFormat;
 
-import com.addthis.basis.util.Parameter;
 import com.addthis.basis.util.LessStrings;
+import com.addthis.basis.util.Parameter;
 
 import com.addthis.bundle.core.Bundle;
-import com.addthis.bundle.core.BundleField;
 import com.addthis.bundle.core.kvp.KVBundle;
+import com.addthis.bundle.util.AutoField;
 import com.addthis.bundle.util.ValueUtil;
 import com.addthis.hydra.common.hash.PluggableHashFunction;
 import com.addthis.hydra.task.source.TaskDataSource;
@@ -62,7 +62,7 @@ public final class MapFeeder implements Runnable {
 
     // mapper task controls
     private final int feeders;
-    private final BundleField shardField;
+    private final AutoField shardField;
     private final Thread[] threads;
     private final BlockingQueue<Bundle>[] queues;
 
@@ -151,7 +151,7 @@ public final class MapFeeder implements Runnable {
             totalBundles++;
             int hash = p.hashCode();
             if (shardField != null) {
-                String val = ValueUtil.asNativeString(p.getValue(shardField));
+                String val = ValueUtil.asNativeString(shardField.getValue(p));
                 if (!LessStrings.isEmpty(val)) {
                     hash = PluggableHashFunction.hash(val);
                 }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/MapFeederForkJoin.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/MapFeederForkJoin.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.task.map;
+
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RecursiveAction;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.addthis.basis.util.Parameter;
+
+import com.addthis.bundle.core.Bundle;
+import com.addthis.hydra.task.source.TaskDataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class MapFeederForkJoin implements Runnable {
+    private static final Logger log = LoggerFactory.getLogger(MapFeederForkJoin.class);
+
+    private static final int QUEUE_DEPTH = Parameter.intValue("task.queue.depth", 100);
+
+    // state control
+    private final AtomicBoolean errored = new AtomicBoolean(false);
+    private boolean hasClosedStreams = false; // not shared with MapperTasks
+
+    // enclosing task
+    private final StreamMapper task;
+    private final TaskDataSource source;
+
+    // mapper task controls
+    private final ForkJoinPool mapperPool;
+    private final int parallelism;
+    private final Semaphore enqueuePermits;
+
+    private long start = System.currentTimeMillis();
+    private long totalBundles = 0;
+
+    public MapFeederForkJoin(StreamMapper task, TaskDataSource source, int parallelism) {
+        this.source = source;
+        this.task = task;
+        this.parallelism = parallelism;
+        this.mapperPool = new ForkJoinPool(parallelism);
+        this.enqueuePermits = new Semaphore(QUEUE_DEPTH);
+    }
+
+    @Override public void run() {
+        log.info("starting {} thread(s) for src={}", parallelism, source);
+        try {
+            if (source.isEnabled()) {
+                while (fillBuffer()) {
+                    if (Thread.interrupted()) {
+                        closeSourceIfNeeded();
+                    }
+                }
+            }
+            closeSourceIfNeeded();
+            joinProcessors();
+            log.info("all ({}) task threads exited; sending taskComplete", parallelism);
+            logBundleThroughput();
+            // run in different threads to isolate them from interrupts. ie. "taskCompleteUninterruptibly"
+            // join awaits completion, is uninterruptible, and will propagate any exception
+            CompletableFuture.runAsync(task::taskComplete).join();
+        } catch (Throwable t) {
+            logBundleThroughput();
+            handleUncaughtThrowable(t);
+        }
+        log.debug("task feeder exited");
+    }
+
+    private void logBundleThroughput() {
+        long elapse = (System.currentTimeMillis() - start) / 1000;
+        log.info("{} bundles processed in {} seconds (avg rate={}/s)", totalBundles, elapse, totalBundles / elapse);
+    }
+
+    /**
+     * Immediately halting is the best way we have of ensuring errors are reported without a significantly
+     * more involved system.
+     */
+    private void handleUncaughtThrowable(Throwable t) {
+        if (errored.compareAndSet(false, true)) {
+            log.error("unrecoverable error in task feeder or one of its mapper threads. immediately halting jvm", t);
+            Runtime.getRuntime().halt(1);
+        }
+    }
+
+    /**
+     * Push the next bundle onto the work queue. Returns true
+     * to continue processing. If another thread has interrupted
+     * ourselves then set our interrupt status. This will close
+     * the current source and continue to consume any remaining elements
+     * from the queue.
+     */
+    private boolean fillBuffer() {
+        boolean status = false;
+        try {
+            enqueuePermits.acquire();
+            Bundle p = source.next();
+            if (p == null) {
+                log.info("exiting on null bundle from {}", source);
+            } else {
+                totalBundles++;
+                mapperPool.submit(new MapperTask(p));
+                status = true;
+            }
+        } catch (NoSuchElementException ignored) {
+            log.info("exiting on premature stream termination");
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+            status = true;
+        }
+        return status;
+    }
+
+    private void joinProcessors() {
+        mapperPool.shutdown();
+    }
+
+    private void closeSourceIfNeeded() {
+        if (!hasClosedStreams) {
+            hasClosedStreams = true;
+            log.info("closing stream {}", source.getClass().getSimpleName());
+            // TODO: better API/ force sources to behave more sensibly
+            CompletableFuture.runAsync(source::close).join();
+        }
+    }
+
+    private class MapperTask extends RecursiveAction {
+
+        private final Bundle input;
+
+        public MapperTask(Bundle input) {
+            this.input = input;
+        }
+
+        @Override protected void compute() {
+            try {
+                task.process(input);
+            } catch (Throwable t) {
+                handleUncaughtThrowable(t);
+            } finally {
+                enqueuePermits.release();
+            }
+        }
+    }
+}

--- a/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamMapper.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/map/StreamMapper.java
@@ -124,6 +124,12 @@ public class StreamMapper implements StreamEmitter, TaskRunnable {
     private final boolean validateDirs;
 
     /**
+     * Duration to wait for outstanding processor tasks
+     * to finish on shutdown. Default is "60 seconds"
+     */
+    private final int taskFinishTimeout;
+
+    /**
      * Use MapFeederForkJoin if true; Otherwise use original MapFeeder.
      *
      * Default is false. This is a temporary flag that allows us to selectively test the
@@ -168,6 +174,7 @@ public class StreamMapper implements StreamEmitter, TaskRunnable {
             @JsonProperty("emitTaskState") boolean emitTaskState,
             @JsonProperty("dateFormat") SimpleDateFormat dateFormat,
             @JsonProperty("validateDirs") boolean validateDirs,
+            @JsonProperty("taskFinishTimeout") @Time(TimeUnit.SECONDS) int taskFinishTimeout,
             @JsonProperty("useForkJoinMapFeeder") boolean useForkJoinMapFeeder) {
         this.source = source;
         this.map = map;
@@ -180,6 +187,7 @@ public class StreamMapper implements StreamEmitter, TaskRunnable {
         this.emitTaskState = emitTaskState;
         this.dateFormat = dateFormat;
         this.validateDirs = validateDirs;
+        this.taskFinishTimeout = taskFinishTimeout;
         this.useForkJoinMapFeeder = useForkJoinMapFeeder;
         validateWritableRootPaths();
     }
@@ -471,4 +479,7 @@ public class StreamMapper implements StreamEmitter, TaskRunnable {
         }
     }
 
+    public int getTaskFinishTimeout() {
+        return taskFinishTimeout;
+    }
 }

--- a/hydra-task/src/main/resources/reference.conf
+++ b/hydra-task/src/main/resources/reference.conf
@@ -67,6 +67,7 @@ com.addthis.hydra.task.map.StreamMapper {
   emitTaskState: true
   dateFormat: "yyMMdd-HHmmss"
   validateDirs: false
+  useForkJoinMapFeeder: false
   map {}
 
   threads: ${?task.threads}

--- a/hydra-task/src/main/resources/reference.conf
+++ b/hydra-task/src/main/resources/reference.conf
@@ -67,6 +67,7 @@ com.addthis.hydra.task.map.StreamMapper {
   emitTaskState: true
   dateFormat: "yyMMdd-HHmmss"
   validateDirs: false
+  taskFinishTimeout: "60 seconds"
   useForkJoinMapFeeder: false
   map {}
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
     <!-- addthis dependency versions -->
     <hydra.dep.bark.version>2.1.4</hydra.dep.bark.version>
-    <hydra.dep.basis.version>2.3.2</hydra.dep.basis.version>
+    <hydra.dep.basis.version>2.3.3-SNAPSHOT</hydra.dep.basis.version>
     <hydra.dep.bundle.version>2.7.3</hydra.dep.bundle.version>
     <hydra.dep.codec.version>3.4.2</hydra.dep.codec.version>
     <hydra.dep.meshy.version>3.3.4</hydra.dep.meshy.version>


### PR DESCRIPTION
In my local synthetic tests that simulates a few corner cases, the new MapFeederForkJoin achieved better bundle processing throughput than the current impl. In a test where I copied real source data and job config, it did the same.