### PR TITLE
Add Spawn#unsafeGetJob() endpoint.

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/job/alert/AbstractJobAlert.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/alert/AbstractJobAlert.java
@@ -271,12 +271,12 @@ public abstract class AbstractJobAlert implements Codable {
         Set<Job> rv = new HashSet<>();
         Map<String, List<String>> aliases = spawn.getAliasManager().getAliases();
         for (String lookupId : jobIds) {
-            Job job = spawn.getJob(lookupId);
+            Job job = spawn.unsafeGetJob(lookupId);
             if (job != null) {
                 rv.add(job);
             } else if (aliases.containsKey(lookupId)) {
                 for (String jobId : aliases.get(lookupId)) {
-                    job = spawn.getJob(jobId);
+                    job = spawn.unsafeGetJob(jobId);
                     if (job != null) {
                         rv.add(job);
                     }
@@ -300,7 +300,7 @@ public abstract class AbstractJobAlert implements Codable {
             }
         }
         for (String lookupId : activeJobs.keySet()) {
-            Job job = spawn.getJob(lookupId);
+            Job job = spawn.unsafeGetJob(lookupId);
             if (job != null) {
                 rv.add(job);
             }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/alert/JobAlertRunner.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/alert/JobAlertRunner.java
@@ -179,49 +179,52 @@ public class JobAlertRunner {
         int done = 0;
         int numNodes = 0;
 
-        List<JobTask> jobNodes = job.getCopyOfTasks();
+        StringBuffer sb = new StringBuffer();
 
-        if (jobNodes != null) {
-            numNodes = jobNodes.size();
-            for (JobTask task : jobNodes) {
-                files += task.getFileCount();
-                bytes += task.getByteCount();
+        if (job != null) {
 
-                if (!task.getState().equals(JobTaskState.IDLE)) {
-                    running++;
-                }
-                switch (task.getState()) {
-                    case IDLE:
-                        done++;
-                        break;
-                    case ERROR:
-                        done++;
-                        errored++;
-                        break;
-                    default:
-                        break;
+            List<JobTask> jobNodes = job.getCopyOfTasks();
+
+            if (jobNodes != null) {
+                numNodes = jobNodes.size();
+                for (JobTask task : jobNodes) {
+                    files += task.getFileCount();
+                    bytes += task.getByteCount();
+
+                    if (!task.getState().equals(JobTaskState.IDLE)) {
+                        running++;
+                    }
+                    switch (task.getState()) {
+                        case IDLE:
+                            done++;
+                            break;
+                        case ERROR:
+                            done++;
+                            errored++;
+                            break;
+                        default:
+                            break;
+                    }
                 }
             }
+            sb.append("Cluster : " + clusterHead + "\n");
+            sb.append("Job : " + job.getId() + "\n");
+            sb.append("Job Link : http://" + clusterHead + ":5052/spawn2/index.html#jobs/" + job.getId() + "/tasks\n");
+            sb.append("Description : " + job.getDescription() + "\n");
+            sb.append("------------------------------ \n");
+            sb.append("Task Summary \n");
+            sb.append("------------------------------ \n");
+            sb.append("Job State : " + job.getState() + "\n");
+            sb.append("Start Time : " + format(job.getStartTime()) + "\n");
+            sb.append("End Time : " + format(job.getEndTime()) + "\n");
+            sb.append("Num Nodes : " + numNodes + "\n");
+            sb.append("Running Nodes : " + running + "\n");
+            sb.append("Errored Nodes : " + errored + "\n");
+            sb.append("Done Nodes : " + done + "\n");
+            sb.append("Task files : " + files + "\n");
+            sb.append("Task Bytes : " + format(bytes) + " GB\n");
+            sb.append("------------------------------ \n");
         }
-
-        StringBuffer sb = new StringBuffer();
-        sb.append("Cluster : " + clusterHead + "\n");
-        sb.append("Job : " + job.getId() + "\n");
-        sb.append("Job Link : http://" + clusterHead + ":5052/spawn2/index.html#jobs/" + job.getId() + "/tasks\n");
-        sb.append("Description : " + job.getDescription() + "\n");
-        sb.append("------------------------------ \n");
-        sb.append("Task Summary \n");
-        sb.append("------------------------------ \n");
-        sb.append("Job State : " + job.getState() + "\n");
-        sb.append("Start Time : " + format(job.getStartTime()) + "\n");
-        sb.append("End Time : " + format(job.getEndTime()) + "\n");
-        sb.append("Num Nodes : " + numNodes + "\n");
-        sb.append("Running Nodes : " + running + "\n");
-        sb.append("Errored Nodes : " + errored + "\n");
-        sb.append("Done Nodes : " + done + "\n");
-        sb.append("Task files : " + files + "\n");
-        sb.append("Task Bytes : " + format(bytes) + " GB\n");
-        sb.append("------------------------------ \n");
         return sb.toString();
     }
 
@@ -258,7 +261,7 @@ public class JobAlertRunner {
             sb.append("Alert Description : " + description + "\n");
         }
         for (Map.Entry<String, String> entry : errors.entrySet()) {
-            sb.append(summary(spawn.getJob(entry.getKey())) + "\n");
+            sb.append(summary(spawn.unsafeGetJob(entry.getKey())) + "\n");
             sb.append("Error Message\n");
             sb.append(entry.getValue());
             sb.append("\n------------------------------\n");

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/Spawn.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/Spawn.java
@@ -702,6 +702,19 @@ public class Spawn implements Codable, AutoCloseable {
         return lastQueueSize;
     }
 
+    /**
+     * This method does not acquire the job lock and therefore the
+     * job object it returns can be out of date with respect
+     * to any concurrent writers. Calling this method should
+     * be safe if a stale copy of the job is OK to use.
+     */
+    public Job unsafeGetJob(String jobUUID) {
+        if (jobUUID == null) {
+            return null;
+        }
+        return spawnState.jobs.get(jobUUID);
+    }
+
     public Job getJob(String jobUUID) {
         if (jobUUID == null) {
             return null;


### PR DESCRIPTION
For use cases when reading a stale copy of a job is OK. With 7b2a9119ad1b5a70f1c960e770d1e33112588775 the known deadlock in Spawn should be fixed. We still have the potential for deadlock in future code as the Spawn#getJob() method acquires the job lock. Which is probably a a good thing except in cases when it's ok to read a stale copy of the job. Such as alerts. The downside of this pull request is that it introduces extra complexity and allows people to bypass the job lock. The job lock may be removed at some point but for now we should respect it (except in those cases we don't need to?)