### PR TITLE
Fixed range docstring to correspond to code

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/query/op/OpString.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/query/op/OpString.java
@@ -68,7 +68,7 @@ import io.netty.channel.ChannelProgressivePromise;
  * <tr>
  * <td>"range" or ":"</td>
  * <td>3</td>
- * <td>take the range of string c from offset a to offset b</td>
+ * <td>take the range of string c from offset b to offset a</td>
  * <td>1</td>
  * </tr>
  * <tr>


### PR DESCRIPTION
Docstring says it does from a to b, but code pops last, then first, then string. Fixed docstring to correspond to code.