### PR TITLE
changing spawn & minion command messages to use (Codec) json

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/AbstractJobMessage.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/AbstractJobMessage.java
@@ -13,12 +13,18 @@
  */
 package com.addthis.hydra.job.mq;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 @SuppressWarnings("serial")
 public abstract class AbstractJobMessage implements JobMessage {
 
-    private String hostUuid;
-    private String jobUuid;
-    private Integer nodeId;
+    @JsonProperty private String hostUuid;
+    @JsonProperty private String jobUuid;
+    @JsonProperty private Integer nodeId;
+
+    @JsonCreator
+    protected AbstractJobMessage() {}
 
     public AbstractJobMessage(String hostUuid, String job, Integer node) {
         this.hostUuid = hostUuid;

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskDelete.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskDelete.java
@@ -13,20 +13,23 @@
  */
 package com.addthis.hydra.job.mq;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = CommandTaskDelete.class)
 public class CommandTaskDelete extends AbstractJobMessage {
 
-    private static final long serialVersionUID = 4855355176382463012L;
+    @JsonProperty private int runCount;
 
-    private int runCount;
+    @JsonCreator
+    private CommandTaskDelete() {
+        super();
+    }
 
     public CommandTaskDelete(String hostUuid, String job, Integer node, int runCount) {
         super(hostUuid, job, node);
         this.runCount = runCount;
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.CMD_TASK_DELETE;
     }
 
     public int getRunCount() {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskKick.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskKick.java
@@ -13,45 +13,37 @@
  */
 package com.addthis.hydra.job.mq;
 
-import com.addthis.codec.annotations.FieldConfig;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonIgnoreProperties({"killSignal", "retries"})
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = CommandTaskKick.class)
 public class CommandTaskKick implements JobMessage {
 
-    private static final long serialVersionUID = -7588140676324569251L;
+    @JsonProperty private String hostUuid;
+    @JsonProperty private JobKey jobKey;
+    @JsonProperty private String owner;
+    @JsonProperty private String userGroup;
+    @JsonProperty private int priority;
+    @JsonProperty private int jobNodes;
+    @JsonProperty private long runTime;
+    @JsonProperty private Long submitTime;
+    @JsonProperty private int runCount;
+    @JsonProperty private int starts;
+    @JsonProperty private String config;
+    @JsonProperty private String command;
+    @JsonProperty private int hourlyBackups;
+    @JsonProperty private int dailyBackups;
+    @JsonProperty private int weeklyBackups;
+    @JsonProperty private int monthlyBackups;
+    @JsonProperty private ReplicaTarget[] replicas;
+    @JsonProperty private boolean autoRetry;
 
-    @FieldConfig private String hostUuid;
-    @FieldConfig private JobKey jobKey;
-    @FieldConfig private String owner;
-    @FieldConfig private String userGroup;
-    @FieldConfig private int priority;
-    @FieldConfig private int jobNodes;
-    @FieldConfig private long runTime;
-    @FieldConfig private Long submitTime;
-    @FieldConfig private int runCount;
-    @FieldConfig private int starts;
-    @FieldConfig private String config;
-    @FieldConfig private String command;
-    @FieldConfig private int hourlyBackups;
-    @FieldConfig private int dailyBackups;
-    @FieldConfig private int weeklyBackups;
-    @FieldConfig private int monthlyBackups;
-    @FieldConfig private ReplicaTarget[] replicas;
-    @FieldConfig private boolean autoRetry;
-
-    @Override
-    public String toString() {
-        return "[K|" + jobKey + "|" + jobNodes + "|" + priority + "]";
-    }
-
-    public String key() {
-        return getJobKey().toString();
-    }
-
-    public CommandTaskKick() {}
+    @JsonCreator
+    private CommandTaskKick() {}
 
     public CommandTaskKick(String host, JobKey jobKey, String owner, String userGroup, int priority, int jobNodes, long runTime,
                            int runCount, String config, String command, int hourlyBackups,
@@ -85,11 +77,6 @@ public class CommandTaskKick implements JobMessage {
     @Override @JsonIgnore
     public Integer getNodeID() {
         return jobKey.getNodeNumber();
-    }
-
-    @Override @JsonIgnore
-    public TYPE getMessageType() {
-        return TYPE.CMD_TASK_KICK;
     }
 
     @Override public String getHostUuid() {
@@ -177,5 +164,14 @@ public class CommandTaskKick implements JobMessage {
 
     public int getStarts() {
         return starts;
+    }
+
+    @Override
+    public String toString() {
+        return "[K|" + jobKey + "|" + jobNodes + "|" + priority + "]";
+    }
+
+    public String key() {
+        return getJobKey().toString();
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskKick.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskKick.java
@@ -21,10 +21,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties({"killSignal", "retries"})
 public class CommandTaskKick implements JobMessage {
 
-    private static final long serialVersionUID = -7588140676324569250L;
+    private static final long serialVersionUID = -7588140676324569251L;
 
     @FieldConfig private String hostUuid;
     @FieldConfig private JobKey jobKey;
+    @FieldConfig private String owner;
+    @FieldConfig private String userGroup;
     @FieldConfig private int priority;
     @FieldConfig private int jobNodes;
     @FieldConfig private long runTime;
@@ -51,12 +53,14 @@ public class CommandTaskKick implements JobMessage {
 
     public CommandTaskKick() {}
 
-    public CommandTaskKick(String host, JobKey jobKey, int priority, int jobNodes, long runTime,
+    public CommandTaskKick(String host, JobKey jobKey, String owner, String userGroup, int priority, int jobNodes, long runTime,
                            int runCount, String config, String command, int hourlyBackups,
                            int dailyBackups, int weeklyBackups, int monthlyBackups, ReplicaTarget[] replicas,
                            boolean autoRetry, int starts) {
         this.hostUuid = host;
         this.jobKey = jobKey;
+        this.owner = owner;
+        this.userGroup = userGroup;
         this.priority = priority;
         this.jobNodes = jobNodes;
         this.runTime = runTime;
@@ -96,6 +100,13 @@ public class CommandTaskKick implements JobMessage {
         return jobKey;
     }
 
+    public String getOwner() {
+        return this.owner;
+    }
+
+    public String getUserGroup() {
+        return this.userGroup;
+    }
     public int getJobNodes() {
         return jobNodes;
     }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskNew.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskNew.java
@@ -13,17 +13,18 @@
  */
 package com.addthis.hydra.job.mq;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = CommandTaskNew.class)
 public class CommandTaskNew extends AbstractJobMessage {
 
-    private static final long serialVersionUID = 1117109955580588580L;
+    @JsonCreator
+    private CommandTaskNew() {
+        super();
+    }
 
     public CommandTaskNew(String hostUuid, String job, int node) {
         super(hostUuid, job, node);
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.CMD_TASK_NEW;
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskReplicate.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskReplicate.java
@@ -15,11 +15,35 @@ package com.addthis.hydra.job.mq;
 
 import java.util.Arrays;
 
-import com.addthis.codec.annotations.FieldConfig;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = CommandTaskReplicate.class)
 public class CommandTaskReplicate extends AbstractJobMessage {
 
-    private static final long serialVersionUID = 3232052848594886109L;
+    @JsonProperty
+    private ReplicaTarget[] replicas;
+    @JsonProperty
+    private String choreWatcherKey;
+    // not all jobs replicate on every execution, if this value is true it will force the replica to occur
+    @JsonProperty
+    private boolean force;
+    /* Whether the task was queued when the replication was done. If so, it will be re-queued on completion */
+    @JsonProperty
+    private boolean wasQueued;
+    @JsonProperty
+    private String jobCommand;
+    /* For rebalances, these are the hosts that are gaining/losing a replica */
+    @JsonProperty
+    private String rebalanceSource;
+    @JsonProperty
+    private String rebalanceTarget;
+
+    @JsonCreator
+    private CommandTaskReplicate() {
+        super();
+    }
 
     public CommandTaskReplicate(String hostUuid,
                                 String job,
@@ -37,37 +61,12 @@ public class CommandTaskReplicate extends AbstractJobMessage {
         this.wasQueued = wasQueued;
     }
 
-    @FieldConfig(codable = true)
-    private ReplicaTarget[] replicas;
-    @FieldConfig(codable = true)
-    private String choreWatcherKey;
-    // not all jobs replicate on every execution, if this value is true it will force the replica to occur
-    @FieldConfig(codable = true)
-    private boolean force;
-    @FieldConfig(codable = true)
-    /* Whether the task was queued when the replication was done. If so, it will be re-queued on completion */
-    private boolean wasQueued;
-
-    @FieldConfig(codable = true)
-    private String jobCommand;
-
-    /* For rebalances, these are the hosts that are gaining/losing a replica */
-    @FieldConfig(codable = true)
-    private String rebalanceSource;
-    @FieldConfig(codable = true)
-    private String rebalanceTarget;
-
     public ReplicaTarget[] getReplicas() {
         return replicas;
     }
 
     public String getChoreWatcherKey() {
         return choreWatcherKey;
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.CMD_TASK_REPLICATE;
     }
 
     public String getJobCommand() {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskRevert.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskRevert.java
@@ -13,14 +13,23 @@
  */
 package com.addthis.hydra.job.mq;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = CommandTaskRevert.class)
 public class CommandTaskRevert extends AbstractJobMessage {
 
-    private static final long serialVersionUID = -4421561753136928922L;
-    private final int revision;
-    private final long time;
-    private final String backupType;
-    private final ReplicaTarget[] replicas;
-    private boolean skipMove;
+    @JsonProperty private int revision;
+    @JsonProperty private long time;
+    @JsonProperty private String backupType;
+    @JsonProperty private ReplicaTarget[] replicas;
+    @JsonProperty private boolean skipMove;
+
+    @JsonCreator
+    private CommandTaskRevert() {
+        super();
+    }
 
     public CommandTaskRevert(String host, String job, Integer node, String backupType, int rev, long time, ReplicaTarget[] replicas, boolean skipMove) {
         super(host, job, node);
@@ -57,10 +66,5 @@ public class CommandTaskRevert extends AbstractJobMessage {
     /* Whether to skip the mv gold live step and just rerun the replicate/backup */
     public boolean getSkipMove() {
         return skipMove;
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.CMD_TASK_REVERT;
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskStop.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskStop.java
@@ -13,18 +13,21 @@
  */
 package com.addthis.hydra.job.mq;
 
-import java.io.Serializable;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-public class CommandTaskStop extends AbstractJobMessage implements Serializable {
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = CommandTaskStop.class)
+public class CommandTaskStop extends AbstractJobMessage {
 
-    private static final long serialVersionUID = 4855355176382463012L;
-    private int runCount;
-    private boolean force;
-    private String choreWatcherKey = null;
-    private boolean onlyIfQueued = false;
+    @JsonProperty private int runCount;
+    @JsonProperty private boolean force;
+    @JsonProperty private String choreWatcherKey = null;
+    @JsonProperty private boolean onlyIfQueued = false;
 
-    public boolean getOnlyIfQueued() {
-        return onlyIfQueued;
+    @JsonCreator
+    private CommandTaskStop() {
+        super();
     }
 
     public CommandTaskStop(String host, String job, Integer node, int runCount, boolean force, boolean onlyIfQueued) {
@@ -32,11 +35,6 @@ public class CommandTaskStop extends AbstractJobMessage implements Serializable 
         this.runCount = runCount;
         this.force = force;
         this.onlyIfQueued = onlyIfQueued;
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.CMD_TASK_STOP;
     }
 
     public int getRunCount() {
@@ -65,6 +63,10 @@ public class CommandTaskStop extends AbstractJobMessage implements Serializable 
         int result = runCount;
         result = 31 * result + (force ? 1 : 0);
         return result;
+    }
+
+    public boolean getOnlyIfQueued() {
+        return onlyIfQueued;
     }
 
     public String getChoreWatcherKey() {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskUpdateReplicas.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/CommandTaskUpdateReplicas.java
@@ -18,17 +18,21 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.addthis.codec.annotations.FieldConfig;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = CommandTaskUpdateReplicas.class)
 public class CommandTaskUpdateReplicas extends AbstractJobMessage {
 
-    private static final long serialVersionUID = -293871238710982L;
+    @JsonProperty private Set<String> failedHosts;
 
-    @FieldConfig(codable = true)
-    private final Set<String> failedHosts;
+    @JsonProperty private List<ReplicaTarget> newReplicaHosts;
 
-    @FieldConfig(codable = true)
-    private final List<ReplicaTarget> newReplicaHosts;
+    @JsonCreator
+    private CommandTaskUpdateReplicas() {
+        super();
+    }
 
     public CommandTaskUpdateReplicas(String hostUuid, String job, Integer node, Set<String> failedHosts, List<ReplicaTarget> newReplicaHosts) {
         super(hostUuid, job, node);
@@ -42,10 +46,5 @@ public class CommandTaskUpdateReplicas extends AbstractJobMessage {
 
     public List<ReplicaTarget> getNewReplicaHosts() {
         return newReplicaHosts != null ? newReplicaHosts : new ArrayList<>();
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.CMD_TASK_UPDATE_REPLICAS;
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/CoreMessage.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/CoreMessage.java
@@ -13,35 +13,17 @@
  */
 package com.addthis.hydra.job.mq;
 
-import java.io.Serializable;
-
 import com.addthis.codec.codables.Codable;
 
-public interface CoreMessage extends Codable, Serializable {
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-    enum TYPE {
-        STATUS_HOST_INFO,
-        STATUS_TASK_BEGIN,
-        STATUS_TASK_PORT,
-        STATUS_TASK_END,
-        STATUS_TASK_BACKUP,
-        STATUS_TASK_REPLICATE,
-        STATUS_TASK_REPLICA,
-        CMD_TASK_KICK,
-        CMD_TASK_STOP,
-        CMD_TASK_DELETE,
-        CMD_TASK_REVERT,
-        CMD_TASK_REPLICATE,
-        CMD_TASK_NEW,
-        CMD_TASK_PROMOTE_REPLICA,
-        STATUS_TASK_JUMP_SHIP,
-        STATUS_TASK_REVERT,
-        CMD_TASK_DEMOTE_REPLICA,
-        STATUS_TASK_CANT_BEGIN,
-        CMD_TASK_UPDATE_REPLICAS
-    }
 
-    TYPE getMessageType();
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE,
+                isGetterVisibility=JsonAutoDetect.Visibility.NONE,
+                setterVisibility=JsonAutoDetect.Visibility.NONE)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+public interface CoreMessage extends Codable {
 
     String getHostUuid();
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/HostState.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/HostState.java
@@ -18,64 +18,60 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
-import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.hydra.minion.Minion;
 
 import com.google.common.base.Objects;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonIgnoreProperties({"messageType", "totalLive", "readOnly"})
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = HostState.class)
 public class HostState implements HostMessage {
 
-    private static final long serialVersionUID = 7252930788607795642L;
-
-    @FieldConfig private String host;
-    @FieldConfig private int port;
-    @FieldConfig private String uuid;
-    @FieldConfig private String user;
-    @FieldConfig private String path;
-    @FieldConfig private String group;
+    @JsonProperty private String host;
+    @JsonProperty private int port;
+    @JsonProperty private String uuid;
+    @JsonProperty private String user;
+    @JsonProperty private String path;
+    @JsonProperty private String group;
     // Host State is determined by others zk group membership, by
     // definition it can not persist.
-    @FieldConfig private boolean up;
-    @FieldConfig private long time;
-    @FieldConfig private long uptime;
-    @FieldConfig private int availableTaskSlots;
-    @FieldConfig private int maxTaskSlots;
-    @FieldConfig private JobKey[] running;
-    @FieldConfig private JobKey[] replicating;
-    @FieldConfig private JobKey[] backingup;
-    @FieldConfig private JobKey[] stopped;
-    @FieldConfig private JobKey[] replicas;
-    @FieldConfig private JobKey[] incompleteReplicas;
-    @FieldConfig private JobKey[] queued;
-    @FieldConfig private HostCapacity used;
-    @FieldConfig private HostCapacity max;
-    @FieldConfig private boolean dead;
-    @FieldConfig private long lastUpdateTime;
-    @FieldConfig private double histQueueSize;
-    @FieldConfig private double histWaitTime;
+    @JsonProperty private boolean up;
+    @JsonProperty private long time;
+    @JsonProperty private long uptime;
+    @JsonProperty private int availableTaskSlots;
+    @JsonProperty private int maxTaskSlots;
+    @JsonProperty private JobKey[] running;
+    @JsonProperty private JobKey[] replicating;
+    @JsonProperty private JobKey[] backingup;
+    @JsonProperty private JobKey[] stopped;
+    @JsonProperty private JobKey[] replicas;
+    @JsonProperty private JobKey[] incompleteReplicas;
+    @JsonProperty private JobKey[] queued;
+    @JsonProperty private HostCapacity used;
+    @JsonProperty private HostCapacity max;
+    @JsonProperty private boolean dead;
+    @JsonProperty private long lastUpdateTime;
+    @JsonProperty private double histQueueSize;
+    @JsonProperty private double histWaitTime;
     //TODO:  remove but need this in for now because de-serialization fails without it
-    @FieldConfig private HashMap<String, Double> jobRuntimes = new HashMap<>();
-    @FieldConfig private boolean diskReadOnly;
-    @FieldConfig private boolean disabled;
-    @FieldConfig private double meanActiveTasks;
-    @FieldConfig private String minionTypes;
+    @JsonProperty private HashMap<String, Double> jobRuntimes = new HashMap<>();
+    @JsonProperty private boolean diskReadOnly;
+    @JsonProperty private boolean disabled;
+    @JsonProperty private double meanActiveTasks;
+    @JsonProperty private String minionTypes;
 
     // Do not encode this derived, internal, non-typesafe field
     private HashMap<String, Integer> jobTaskCountMap;
 
-    public HostState() {
-    }
+    @JsonCreator
+    private HostState() {}
 
-    public HostState(String uuid) {
-        this.uuid = uuid;
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.STATUS_HOST_INFO;
+    public HostState(String hostUuid) {
+        this.uuid = hostUuid;
     }
 
     @Override
@@ -83,9 +79,15 @@ public class HostState implements HostMessage {
         return uuid;
     }
 
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    @JsonProperty
     public void setHostUuid(String uuid) {
         this.uuid = uuid;
     }
+
 
     public void setUpdated() {
         lastUpdateTime = System.currentTimeMillis();
@@ -196,7 +198,6 @@ public class HostState implements HostMessage {
     @Override
     public String toString() {
         return Objects.toStringHelper(this)
-                .add("type", getMessageType())
                 .add("uuid", getHostUuid())
                 .add("last-update-time", getLastUpdateTime())
                 .add("host", getHost())

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskBackup.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskBackup.java
@@ -13,16 +13,18 @@
  */
 package com.addthis.hydra.job.mq;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = StatusTaskBackup.class)
 public class StatusTaskBackup extends AbstractJobMessage {
 
-    private static final long serialVersionUID = 3232052848594886109L;
+    @JsonCreator
+    private StatusTaskBackup() {
+        super();
+    }
 
     public StatusTaskBackup(String host, String job, int node) {
         super(host, job, node);
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.STATUS_TASK_BACKUP;
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskBegin.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskBegin.java
@@ -13,16 +13,18 @@
  */
 package com.addthis.hydra.job.mq;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = StatusTaskBegin.class)
 public class StatusTaskBegin extends AbstractJobMessage {
 
-    private static final long serialVersionUID = -4209250141708137377L;
+    @JsonCreator
+    private StatusTaskBegin() {
+        super();
+    }
 
     public StatusTaskBegin(String host, String job, int node) {
         super(host, job, node);
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.STATUS_TASK_BEGIN;
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskCantBegin.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskCantBegin.java
@@ -13,16 +13,18 @@
  */
 package com.addthis.hydra.job.mq;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = StatusTaskCantBegin.class)
 public class StatusTaskCantBegin extends AbstractJobMessage {
 
-    private static final long serialVersionUID = -663325014170813291L;
+    @JsonCreator
+    private StatusTaskCantBegin() {
+        super();
+    }
 
     public StatusTaskCantBegin(String host, String job, int node) {
         super(host, job, node);
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.STATUS_TASK_CANT_BEGIN;
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskEnd.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskEnd.java
@@ -15,17 +15,25 @@ package com.addthis.hydra.job.mq;
 
 import com.addthis.hydra.task.run.TaskExitState;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = StatusTaskEnd.class)
 public class StatusTaskEnd extends AbstractJobMessage {
 
-    private static final long serialVersionUID = -2600124052404240597L;
+    @JsonProperty private int exitCode;
+    @JsonProperty private long fileCount;
+    @JsonProperty private long byteCount;
+    @JsonProperty private TaskExitState exitState;
+    @JsonProperty private String rebalanceSource;
+    @JsonProperty private String rebalanceTarget;
+    @JsonProperty private boolean wasQueued;
 
-    private int exitCode;
-    private long fileCount;
-    private long byteCount;
-    private TaskExitState exitState;
-    private String rebalanceSource;
-    private String rebalanceTarget;
-    private boolean wasQueued;
+    @JsonCreator
+    private StatusTaskEnd() {
+        super();
+    }
 
     public StatusTaskEnd(String host, String job, Integer node, int exit, long files, long bytes) {
         super(host, job, node);
@@ -53,11 +61,6 @@ public class StatusTaskEnd extends AbstractJobMessage {
     public StatusTaskEnd setExitState(TaskExitState exitState) {
         this.exitState = exitState;
         return this;
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.STATUS_TASK_END;
     }
 
     public int getExitCode() {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskPort.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskPort.java
@@ -13,20 +13,23 @@
  */
 package com.addthis.hydra.job.mq;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = StatusTaskPort.class)
 public class StatusTaskPort extends AbstractJobMessage {
 
-    private static final long serialVersionUID = 8452018350634440050L;
+    @JsonProperty private int port;
 
-    private int port;
+    @JsonCreator
+    private StatusTaskPort() {
+        super();
+    }
 
     public StatusTaskPort(String host, String job, Integer node, int port) {
         super(host, job, node);
         this.port = port;
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.STATUS_TASK_PORT;
     }
 
     public int getPort() {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskReplica.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskReplica.java
@@ -13,22 +13,25 @@
  */
 package com.addthis.hydra.job.mq;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = StatusTaskReplica.class)
 public class StatusTaskReplica extends AbstractJobMessage {
 
-    private static final long serialVersionUID = 3232052848594886109L;
+    @JsonProperty private int version;
+    @JsonProperty private long time;
+
+    @JsonCreator
+    private StatusTaskReplica() {
+        super();
+    }
 
     public StatusTaskReplica(String host, String job, int node, int version, long time) {
         super(host, job, node);
         this.version = version;
         this.time = time;
-    }
-
-    private int version;
-    private long time;
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.STATUS_TASK_REPLICA;
     }
 
     public int getVersion() {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskReplicate.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskReplicate.java
@@ -13,10 +13,19 @@
  */
 package com.addthis.hydra.job.mq;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = StatusTaskReplicate.class)
 public class StatusTaskReplicate extends AbstractJobMessage {
 
-    private static final long serialVersionUID = 3232052848594886109L;
-    private boolean isFullReplication;
+    @JsonProperty private boolean isFullReplication;
+
+    @JsonCreator
+    private StatusTaskReplicate() {
+        super();
+    }
 
     public StatusTaskReplicate(String host, String job, int node, boolean isFullReplication) {
         super(host, job, node);
@@ -25,10 +34,5 @@ public class StatusTaskReplicate extends AbstractJobMessage {
 
     public boolean isFullReplication() {
         return isFullReplication;
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.STATUS_TASK_REPLICATE;
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskRevert.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/StatusTaskRevert.java
@@ -13,16 +13,18 @@
  */
 package com.addthis.hydra.job.mq;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, defaultImpl = StatusTaskRevert.class)
 public class StatusTaskRevert extends AbstractJobMessage {
 
-    private static final long serialVersionUID = 928572848594889871L;
+    @JsonCreator
+    private StatusTaskRevert() {
+        super();
+    }
 
     public StatusTaskRevert(String host, String job, int node) {
         super(host, job, node);
-    }
-
-    @Override
-    public TYPE getMessageType() {
-        return TYPE.STATUS_TASK_REVERT;
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/Spawn.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/Spawn.java
@@ -2618,6 +2618,8 @@ public class Spawn implements Codable, AutoCloseable {
         CommandTaskKick kick = new CommandTaskKick(
                 task.getHostUUID(),
                 task.getJobKey(),
+                job.getOwner(),
+                job.getGroup(),
                 job.getPriority(),
                 job.getCopyOfTasks().size(),
                 job.getMaxRunTime() != null ? job.getMaxRunTime() * 60000 : 0,
@@ -2674,9 +2676,11 @@ public class Spawn implements Codable, AutoCloseable {
                 task.setRebalanceTarget(null);
             }
         }
-        CommandTaskKick kick = new CommandTaskKick(
+        final CommandTaskKick kick = new CommandTaskKick(
                 task.getHostUUID(),
                 task.getJobKey(),
+                job.getOwner(),
+                job.getGroup(),
                 job.getPriority(),
                 job.getCopyOfTasks().size(),
                 job.getMaxRunTime() != null ? job.getMaxRunTime() * 60000 : 0,

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/SpawnMQ.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/SpawnMQ.java
@@ -13,8 +13,7 @@
  */
 package com.addthis.hydra.job.spawn;
 
-import java.io.Serializable;
-
+import com.addthis.hydra.job.mq.CoreMessage;
 import com.addthis.hydra.job.mq.HostMessage;
 import com.addthis.hydra.mq.MessageListener;
 
@@ -22,7 +21,7 @@ import com.addthis.hydra.mq.MessageListener;
 /**
  * interface for Spawn messaging
  */
-public interface SpawnMQ extends MessageListener {
+public interface SpawnMQ extends MessageListener<CoreMessage> {
 
     /**
      * connect to messaging infrastructure
@@ -38,21 +37,21 @@ public interface SpawnMQ extends MessageListener {
      * @param message - the incoming message
      */
     @Override
-    void onMessage(Serializable message);
+    void onMessage(CoreMessage message);
 
     /**
      * Send a message to the control channel
      *
      * @param msg - the message to send
      */
-    void sendControlMessage(HostMessage msg);
+    void sendControlMessage(CoreMessage msg);
 
     /**
      * Send a message to the job channel
      *
      * @param msg - the message to send
      */
-    void sendJobMessage(HostMessage msg);
+    void sendJobMessage(CoreMessage msg);
 
     /**
      * closes all of the connections

--- a/hydra-main/src/main/java/com/addthis/hydra/minion/JobTask.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/minion/JobTask.java
@@ -831,8 +831,10 @@ public class JobTask implements Codable {
                                    .replace("{{node}}", String.valueOf(jobNode))
                                    .replace("{{nodes}}", String.valueOf(jobNodes));
             String setEnvironmentPrefix = String.format(
-                    "HYDRA_JOBDIR='%s' HYDRA_JOBID='%s' HYDRA_NODE='%s' HYDRA_NODES='%s' HYDRA_PORT='%s'",
-                    jobDir.getPath(), jobId, jobNode, jobNodes, portString);
+                    "HYDRA_JOBDIR='%s' HYDRA_JOBID='%s' HYDRA_NODE='%s' HYDRA_NODES='%s' " +
+                    "HYDRA_OWNER='%s' HYDRA_USERGROUP='%s' HYDRA_PORT='%s'",
+                    jobDir.getPath(), jobId, jobNode, jobNodes,
+                    kickMessage.getOwner(), kickMessage.getUserGroup(), portString);
             log.warn("[task.exec] starting {} with autoRetry={}", jobDir.getPath(), autoRetry);
             // create shell wrapper
             require(minion.deleteFiles(jobPid, jobPort, jobDone, jobStopped), "failed to delete files");

--- a/hydra-mq/src/main/java/com/addthis/hydra/mq/MessageConsumer.java
+++ b/hydra-mq/src/main/java/com/addthis/hydra/mq/MessageConsumer.java
@@ -15,13 +15,13 @@ package com.addthis.hydra.mq;
 
 import java.io.IOException;
 
-public interface MessageConsumer {
+public interface MessageConsumer<T> {
 
     void open() throws IOException;
 
     void close() throws IOException;
 
-    boolean addMessageListener(MessageListener messageListener);
+    boolean addMessageListener(MessageListener<T> messageListener);
 
-    boolean removeMessageListener(MessageListener messageListener);
+    boolean removeMessageListener(MessageListener<T> messageListener);
 }

--- a/hydra-mq/src/main/java/com/addthis/hydra/mq/MessageListener.java
+++ b/hydra-mq/src/main/java/com/addthis/hydra/mq/MessageListener.java
@@ -13,9 +13,7 @@
  */
 package com.addthis.hydra.mq;
 
-import java.io.Serializable;
+public interface MessageListener<T> {
 
-public interface MessageListener {
-
-    void onMessage(Serializable message);
+    void onMessage(T message);
 }

--- a/hydra-mq/src/main/java/com/addthis/hydra/mq/MessageProducer.java
+++ b/hydra-mq/src/main/java/com/addthis/hydra/mq/MessageProducer.java
@@ -15,10 +15,9 @@ package com.addthis.hydra.mq;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.Serializable;
 
-public interface MessageProducer extends Closeable {
+public interface MessageProducer<T> extends Closeable {
 
-    void sendMessage(Serializable message, String routingKey) throws IOException;
+    void sendMessage(T message, String routingKey) throws IOException;
 
 }

--- a/hydra-mq/src/main/java/com/addthis/hydra/mq/ZKMessageProducer.java
+++ b/hydra-mq/src/main/java/com/addthis/hydra/mq/ZKMessageProducer.java
@@ -14,9 +14,8 @@
 package com.addthis.hydra.mq;
 
 import java.io.IOException;
-import java.io.Serializable;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.addthis.codec.jackson.Jackson;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.KeeperException;
@@ -24,16 +23,14 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ZKMessageProducer implements MessageProducer {
+public class ZKMessageProducer<T> implements MessageProducer<T> {
 
     private static final Logger log = LoggerFactory.getLogger(ZKMessageProducer.class);
 
     private final CuratorFramework zkClient;
-    private final ObjectMapper mapper;
 
     public ZKMessageProducer(CuratorFramework zkClient) {
         this.zkClient = zkClient;
-        this.mapper = new ObjectMapper();
     }
 
     @Override
@@ -42,12 +39,12 @@ public class ZKMessageProducer implements MessageProducer {
     }
 
     @Override
-    public void sendMessage(Serializable message, String routingKey) throws IOException {
+    public void sendMessage(T message, String routingKey) throws IOException {
         try {
             try {
-                zkClient.create().creatingParentsIfNeeded().forPath(routingKey, mapper.writeValueAsBytes(message));
+                zkClient.create().creatingParentsIfNeeded().forPath(routingKey, Jackson.defaultMapper().writeValueAsBytes(message));
             } catch (KeeperException.NodeExistsException e) {
-                zkClient.setData().forPath(routingKey, mapper.writeValueAsBytes(message));
+                zkClient.setData().forPath(routingKey, Jackson.defaultMapper().writeValueAsBytes(message));
             }
         } catch (Exception e) {
             throw new IOException(e);


### PR DESCRIPTION
Original purpose of these changes was to add some addition fields (owner and group) to kick commands for resource usage tracking.  Ended up making a variety of changes/clean-up so this sort of thing would be easier in the future.

Note, since the serialization format for command messages is changing, this would cause any persisted messages in the old format to be be dropped.  This should not be a problem for us since the standard release process clears all non-repeating messages from the queue.

Note, I haven't finished testing yet, but I wanted to start the review as soon as possible so this can make it into Monday's release.