### PR TITLE
Fix HttpOutputWriter retry logic, which currently terminates after th…

### DIFF
--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/HttpOutputWriter.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/HttpOutputWriter.java
@@ -50,7 +50,6 @@ import com.github.rholder.retry.WaitStrategies;
 
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.http.HttpEntity;
-import org.apache.http.NoHttpResponseException;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -145,7 +144,7 @@ public class HttpOutputWriter extends AbstractOutputWriter {
                                  .build();
         RetryerBuilder<Integer> retryerBuilder = RetryerBuilder
                 .<Integer>newBuilder()
-                .retryIfExceptionOfType(NoHttpResponseException.class)
+                .retryIfExceptionOfType(UncheckedIOException.class)
                 .retryIfResult((val) -> (val == null) || !(val >= 200 && val < 300))
                 .withStopStrategy(StopStrategies.stopAfterAttempt(retries));
         if (backoffMax > 0) {


### PR DESCRIPTION
…e first failure.

The following test exposes the issue (fails on first retry with existing code, but correctly attempts further retries with fixed code.) The 'request' method in HttpOutputWriter must be changed to public/protected to run the test.

import javax.annotation.Nonnull;

import java.io.IOException;
import java.io.UncheckedIOException;

import java.util.concurrent.TimeUnit;

import com.addthis.bundle.core.list.ListBundle;
import com.addthis.bundle.value.ValueFactory;
import com.addthis.codec.annotations.Time;
import com.addthis.codec.config.Configs;

import com.google.common.collect.ImmutableMap;

import com.fasterxml.jackson.annotation.JsonProperty;

import org.apache.commons.lang3.mutable.MutableInt;
import org.apache.http.NoHttpResponseException;

import org.junit.Test;
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;

public class DontCommitTest {

    @Test public void dontCommitTest() throws IOException {
        FailingHttpOutputWriter c = Configs.decodeObject(FailingHttpOutputWriter.class,
                                                    "{\"fields\":[\"a\"], \"requestType\":\"POST\", \"retries\": 50, " +
                                                    "\"maxConnTotal\": 3, \"maxConnPerRoute\":3, \"timeout\":10, " +
                                                    "\"backoffMax\":25000}");
        c.open();
        try {
            ListBundle bun = new ListBundle(ImmutableMap.of("a", ValueFactory.create("bbb")));
            c.writeLine("aaa", bun);
        } finally {
            c.closeOpenOutputs();
        }
    }


    public static class FailingHttpOutputWriter extends HttpOutputWriter {
        private static final Logger logger = LoggerFactory.getLogger(FailingHttpOutputWriter.class);
        public FailingHttpOutputWriter(@JsonProperty(value = "fields", required = true) String[] fields,
                                       @JsonProperty(value = "requestType") String requestType,
                                       @JsonProperty(value = "retries") int retries,
                                       @JsonProperty(value = "maxConnTotal") int maxConnTotal,
                                       @JsonProperty(value = "maxConnPerRoute") int maxConnPerRoute,
                                       @JsonProperty(value = "timeout") @Time(TimeUnit.MILLISECONDS) int timeout,
                                       @JsonProperty(value = "backoffMax") @Time(TimeUnit.MILLISECONDS) int backoffMax) {
            super(fields, requestType, retries, maxConnTotal, maxConnPerRoute, timeout, backoffMax);
        }

        @Nonnull @Override public Integer request(String[] endpoints, String body, MutableInt retry) {
            logger.error("TRIED TO HIT ENDPOINT");
            throw new UncheckedIOException(new NoHttpResponseException("xxxx"));
        }
    }
}
