### PR TITLE
Fixed distribution when point size < sample size

### DIFF
--- a/hydra-data/src/main/java/com/addthis/hydra/data/util/KeyPercentileDistribution.java
+++ b/hydra-data/src/main/java/com/addthis/hydra/data/util/KeyPercentileDistribution.java
@@ -15,7 +15,6 @@ package com.addthis.hydra.data.util;
 
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.codec.codables.SuperCodable;
-
 import com.yammer.metrics.stats.CodableUniformSample;
 import com.yammer.metrics.stats.Snapshot;
 

--- a/hydra-data/src/main/java/com/yammer/metrics/stats/CodableUniformSample.java
+++ b/hydra-data/src/main/java/com/yammer/metrics/stats/CodableUniformSample.java
@@ -14,7 +14,6 @@
 package com.yammer.metrics.stats;
 
 import com.addthis.codec.annotations.FieldConfig;
-
 import com.google.common.primitives.Longs;
 
 /**
@@ -89,6 +88,6 @@ public class CodableUniformSample implements Sample {
 
     @Override
     public Snapshot getSnapshot() {
-        return new Snapshot(Longs.asList(values));
+        return new Snapshot(Longs.asList(values).subList(0, size()));
     }
 }

--- a/hydra-data/src/test/java/com/addthis/hydra/data/util/TestKeyPercentileDistribution.java
+++ b/hydra-data/src/test/java/com/addthis/hydra/data/util/TestKeyPercentileDistribution.java
@@ -1,0 +1,41 @@
+package com.addthis.hydra.data.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestKeyPercentileDistribution {
+
+    @Test
+    public void stats() {
+        KeyPercentileDistribution distribution = new KeyPercentileDistribution(10).init();
+        distribution.update(1);
+        distribution.update(2);
+        distribution.update(2);
+        distribution.update(3);
+
+        Assert.assertEquals(4, distribution.count());
+        Assert.assertEquals(Math.sqrt(0.666666666666666), distribution.stdDev(), 10E-15);
+        Assert.assertEquals(1, distribution.min());
+        Assert.assertEquals(3, distribution.max());
+    }
+
+    @Test
+    public void lessDataPointsThanSampleSize() {
+        KeyPercentileDistribution distribution = new KeyPercentileDistribution(100).init();
+        for (int i = 0; i < 50; i++) {
+            distribution.update(i);
+        }
+
+        Assert.assertEquals(50, distribution.getSnapshot().size());
+    }
+
+    @Test
+    public void moreDataPointsThanSampleSize() {
+        KeyPercentileDistribution distribution = new KeyPercentileDistribution(10).init();
+        for (int i = 0; i < 15; i++) {
+            distribution.update(i);
+        }
+
+        Assert.assertEquals(10, distribution.getSnapshot().size());
+    }
+}


### PR DESCRIPTION
Currently, when the distribution has less data points than the reservoir size the distribution is heavily skewed with 0 values. The fix for this is to pass the snapshot a sublist.
