### PR TITLE
squid:S1860 - Synchronization should not be based on Strings or boxed primitives

### DIFF
--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRandom.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/value/ValueFilterRandom.java
@@ -39,6 +39,7 @@ import com.addthis.codec.annotations.FieldConfig;
  */
 public class ValueFilterRandom extends AbstractValueFilter {
 
+    private static final Object lock = new Object();
     private final Random random = new Random();
 
     /**
@@ -91,7 +92,7 @@ public class ValueFilterRandom extends AbstractValueFilter {
     @Override
     public ValueObject filterValue(ValueObject value) {
         if (gaussian) {
-            synchronized (nextGaussian) {
+            synchronized (lock) {
                 return ValueFactory.create(nextGaussian(mu, sigma));
             }
         }

--- a/hydra-task/src/main/java/com/addthis/hydra/task/source/FactoryInputStream.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/source/FactoryInputStream.java
@@ -84,12 +84,13 @@ public abstract class FactoryInputStream implements Codable {
      */
     public static final class InjectorStreamSource extends FactoryInputStream {
 
+        private static final Object lock = new Object();
         public static final String DefautlInjectorKey = "secretDefaultInjectorKey";
         private static final IdentityHashMap<String, LinkedBlockingQueue<InputStream>> park = new IdentityHashMap<>();
 
         public static final void inject(String key, InputStream in) {
             key = key.intern();
-            synchronized (key) {
+            synchronized (lock) {
                 try {
                     LinkedBlockingQueue<InputStream> queue = null;
                     synchronized (park) {
@@ -120,7 +121,7 @@ public abstract class FactoryInputStream implements Codable {
             try {
                 while (queue == null) {
                     key = key.intern();
-                    synchronized (key) {
+                    synchronized (lock) {
                         synchronized (park) {
                             queue = park.get(key);
                         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1860 - Synchronization should not be based on Strings or boxed primitives.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1860
Please let me know if you have any questions.
George Kankava