### PR TITLE
Spawn task log proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ test.http.get/
 .project
 .settings/
 .idea/
+hydra-auth/
+hydra-main/etc/
+hydra-main/log/
 hydra-local/
 hydra-data/indexes/
 hydra-data/query.tmp

--- a/hydra-main/src/main/java/com/addthis/hydra/job/web/resources/JobsResource.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/web/resources/JobsResource.java
@@ -20,6 +20,7 @@ import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
@@ -89,6 +90,11 @@ import com.typesafe.config.ConfigResolveOptions;
 import com.typesafe.config.ConfigValue;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -862,6 +868,61 @@ public class JobsResource {
         }
     }
 
+    // http://localhost:5052/job/f641cc5a-e3bf-48c4-a533-c6f35045b45c/log?out=1&lines=10&node=0&runsAgo=0
+
+    @GET
+    @Path("/{jobID}/log")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getJobTaskLog(@PathParam("jobID") String jobID,
+                                  @QueryParam("lines") @DefaultValue("50") int lines,
+                                  @QueryParam("runsAgo") @DefaultValue("0") int runsAgo,
+                                  @QueryParam("out") @DefaultValue("1") int out,
+                                  @QueryParam("minion") String minion,
+                                  @QueryParam("port") String port,
+                                  @QueryParam("node") String node) {
+        JSONObject body = new JSONObject();
+        boolean error = false;
+        try {
+            if (minion == null) {
+                body.put("error", "Missing required query parameter 'minion'");
+                return Response.status(Response.Status.BAD_REQUEST).entity(body.toString()).build();
+            } else if (node == null) {
+                body.put("error", "Missing required query parameter 'node'");
+                return Response.status(Response.Status.BAD_REQUEST).entity(body.toString()).build();
+            } else if (port == null) {
+                body.put("error", "Missing required query parameter 'node'");
+                return Response.status(Response.Status.BAD_REQUEST).entity(body.toString()).build();
+            } else {
+                String url = String.format("http://%s:%s/job.log?id=%s&node=%s&runsAgo=%d&lines=%d&out=%d",
+                        minion, port, jobID, node, runsAgo, lines, out);
+                CloseableHttpClient httpclient = HttpClients.createDefault();
+                HttpGet httpGet = new HttpGet(url);
+                CloseableHttpResponse response = httpclient.execute(httpGet);
+
+                try {
+                    HttpEntity entity = response.getEntity();
+                    String responseEncoding = entity.getContentEncoding() != null ?
+                            entity.getContentEncoding().getValue() :
+                            null;
+                    String encoding = responseEncoding == null ? "UTF-8" : responseEncoding;
+                    String responseBody = IOUtils.toString(entity.getContent(), encoding);
+
+                    return Response.status(response.getStatusLine().getStatusCode())
+                            .header("Content-type", response.getFirstHeader("Content-type"))
+                            .entity(responseBody)
+                            .build();
+                } catch (IOException ex) {
+                    return buildServerError(ex);
+                } finally {
+                    response.close();
+                }
+            }
+
+        } catch (Exception ex) {
+            return buildServerError(ex);
+        }
+
+    }
 
     @GET
     @Path("/tasks.get")

--- a/hydra-main/web/spawn2/js/modules/task.log.js
+++ b/hydra-main/web/spawn2/js/modules/task.log.js
@@ -29,8 +29,10 @@ function(
             this.stdout=undefined;
         },
         url:function(){
-            var url= "http://"+this.host+":"+this.port+"/job.log?out="+(this.stdout?'1':'0')+
-            "&id="+this.jobUuid+"&lines="+this.lines+"&node="+this.node+"&runsAgo="+this.runsAgo;
+            var url= "/job/" + this.jobUuid + "/log?out="+ (this.stdout ? "1" : "0") +
+            "&lines=" + this.lines + "&node=" + this.node + "&runsAgo=" + this.runsAgo +
+            "&minion=" + this.host + "&port=" + this.port;
+
             if(!_.isUndefined(this.offset)){
                 url+="&offset="+this.offset;
             }


### PR DESCRIPTION
ea09765
Proxies requests for minion tasks through the main spawn server, instead of having the client hit individual minions for logs. This is a step towards allowing spawn completely over https.

1b4ab3d
I also changed the responses spawn sends back from server exceptions. The endpoints should return JSON, even when they error... There is one endpoint, `/expand`, which does an octet stream, but I don't think this is any less correct than it was before.