### PR TITLE
Add ignoreDiskQuota() to User interface.

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/job/auth/AuthenticationManagerAllowAll.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/auth/AuthenticationManagerAllowAll.java
@@ -46,11 +46,11 @@ class AuthenticationManagerAllowAll extends AuthenticationManager {
     }
 
     @Override User authenticate(String username, String secret) {
-        return new StaticUser(username, ImmutableList.of(), "unused", "unused");
+        return new StaticUser(username, ImmutableList.of(), "unused", "unused", false);
     }
 
     @Override User getUser(String username) {
-        return new StaticUser(username, ImmutableList.of(), "unused", "unused");
+        return new StaticUser(username, ImmutableList.of(), "unused", "unused", false);
     }
 
     @Override String sudoToken(String username) {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/auth/StaticUser.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/auth/StaticUser.java
@@ -37,15 +37,24 @@ public class StaticUser implements User {
     @Nullable
     private final String sudo;
 
+    private final boolean ignoreDiskQuota;
+
     @JsonCreator
     public StaticUser(@JsonProperty("name") String name,
                       @JsonProperty("groups") List<String> groups,
                       @JsonProperty("secret") String secret,
-                      @JsonProperty("sudo") String sudo) {
+                      @JsonProperty("sudo") String sudo,
+                      @JsonProperty("ignoreDiskQuota") boolean ignoreDiskQuota) {
         this.name = name;
         this.groups = (groups == null) ? ImmutableList.of() : ImmutableList.copyOf(groups);
         this.secret = secret;
         this.sudo = sudo;
+        this.ignoreDiskQuota = ignoreDiskQuota;
+    }
+
+    @Override
+    public boolean ignoreDiskQuota() {
+        return ignoreDiskQuota;
     }
 
     @Nonnull @Override public String name() {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/auth/User.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/auth/User.java
@@ -24,6 +24,10 @@ public interface User {
 
     @Nonnull List<String> groups();
 
+    default boolean ignoreDiskQuota() {
+        return false;
+    }
+
     default @Nullable String primaryGroup() {
         List<String> groups = groups();
         if (groups.size() > 0) {

--- a/hydra-main/src/test/java/com/addthis/hydra/job/auth/AuthenticationManagerNestedTest.java
+++ b/hydra-main/src/test/java/com/addthis/hydra/job/auth/AuthenticationManagerNestedTest.java
@@ -23,9 +23,9 @@ import static org.junit.Assert.assertEquals;
 
 public class AuthenticationManagerNestedTest {
 
-    private static StaticUser user1 = new StaticUser("user1", ImmutableList.of("group2"), "unused", null);
-    private static StaticUser user2 = new StaticUser("user2", null, "password2", null);
-    private static StaticUser user3 = new StaticUser("user1", ImmutableList.of("group1"), "password1", null);
+    private static StaticUser user1 = new StaticUser("user1", ImmutableList.of("group2"), "unused", null, false);
+    private static StaticUser user2 = new StaticUser("user2", null, "password2", null, false);
+    private static StaticUser user3 = new StaticUser("user1", ImmutableList.of("group1"), "password1", null, false);
 
     private static List<StaticUser> innerUsers = ImmutableList.of(user3);
     private static List<StaticUser> outerUsers = ImmutableList.of(user1, user2);

--- a/hydra-main/src/test/java/com/addthis/hydra/job/auth/AuthenticationManagerStaticTest.java
+++ b/hydra-main/src/test/java/com/addthis/hydra/job/auth/AuthenticationManagerStaticTest.java
@@ -29,8 +29,8 @@ public class AuthenticationManagerStaticTest {
 
     @Test
     public void authentication() {
-        StaticUser user1 = new StaticUser("user1", ImmutableList.of("group2"), null, null);
-        StaticUser user2 = new StaticUser("user2", null, "password2", null);
+        StaticUser user1 = new StaticUser("user1", ImmutableList.of("group2"), null, null, false);
+        StaticUser user2 = new StaticUser("user2", null, "password2", null, false);
         List<StaticUser> users1 = ImmutableList.of(user1, user2);
         AuthenticationManagerStatic auth = new AuthenticationManagerStatic(users1,
                                                                            ImmutableList.of(),
@@ -45,9 +45,9 @@ public class AuthenticationManagerStaticTest {
 
     @Test
     public void isAdmin() {
-        StaticUser user1 = new StaticUser("user1", ImmutableList.of("group2"), null, null);
-        StaticUser user2 = new StaticUser("user2", null, "password2", null);
-        StaticUser user3 = new StaticUser("user3", ImmutableList.of("group2"), "password3", null);
+        StaticUser user1 = new StaticUser("user1", ImmutableList.of("group2"), null, null, false);
+        StaticUser user2 = new StaticUser("user2", null, "password2", null, false);
+        StaticUser user3 = new StaticUser("user3", ImmutableList.of("group2"), "password3", null, false);
         List<StaticUser> users = ImmutableList.of(user1, user2, user3);
         AuthenticationManagerStatic auth = new AuthenticationManagerStatic(users,
                                                                            ImmutableList.of("group2"),


### PR DESCRIPTION
This new method is intended to support autonomous accounts that should be allowed to ignore any future disk quotas (which are not yet implemented). The field 'ignoreDiskQuota' has been added to the StaticUser POJO. If it is not specified then the default value of false is applicable.