### PR TITLE
removing unnecessary/incorrect sanity check on url length

### DIFF
--- a/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterURL.java
+++ b/hydra-filters/src/main/java/com/addthis/hydra/data/filter/bundle/BundleFilterURL.java
@@ -237,7 +237,7 @@ public final class BundleFilterURL implements BundleFilter {
     public boolean filter(Bundle bundle) {
         String pv = ValueUtil.asNativeString(field.getValue(bundle));
         if (!asFile) {
-            if (pv == null || pv.length() < 7) {
+            if (pv == null) {
                 return invalidExit;
             }
             String lpv = pv.trim().toLowerCase();


### PR DESCRIPTION
BundleFilterURL seems to have an unnecessary sanity check that the url length must be at least 7 characters.  I believe this assumption was based on the url always having a protocol (e.g. "http://" is length 7).

It is not required for the url to contain a protocol, and in particular, this is breaking parsing of the twitter sharing domain, "t.co".

I've traced the code and can't find any places the length 7 of the url string is assumed for indexing, etc.  There's a small chance this change could start passing very short urls that were incorrectly being dropped before in some jobs.