### PR TITLE
workaround for errored jobs blocking fs-ok failure queue

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/job/HostFailWorker.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/HostFailWorker.java
@@ -253,6 +253,11 @@ public class HostFailWorker {
                     return;
                 }
                 List<JobTaskMoveAssignment> assignments = spawn.getSpawnBalancer().pushTasksOffDiskForFilesystemOkayFailure(host, tasksToMove);
+                // no re-assignments available for this host, move it to the end of the fs-ok queue
+                if(assignments.isEmpty() && failState == FailState.FAILING_FS_OKAY) {
+                    hostFailState.removeHost(failedHostUuid);
+                    hostFailState.putHost(failedHostUuid, FailState.FAILING_FS_OKAY);
+                }
                 // Use available task slots to push tasks off the host in question. Not all of these assignments will necessarily be moved.
                 spawn.executeReallocationAssignments(assignments, !diskFull && obeyTaskSlots.get());
                 if (failState == FailState.FAILING_FS_OKAY && assignments.isEmpty() && host.countTotalLive() == 0) {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/HostFailWorker.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/HostFailWorker.java
@@ -255,7 +255,7 @@ public class HostFailWorker {
                 List<JobTaskMoveAssignment> assignments = spawn.getSpawnBalancer().pushTasksOffDiskForFilesystemOkayFailure(host, tasksToMove);
                 // Use available task slots to push tasks off the host in question. Not all of these assignments will necessarily be moved.
                 spawn.executeReallocationAssignments(assignments, !diskFull && obeyTaskSlots.get());
-                if (failState == FailState.FAILING_FS_OKAY && assignments.isEmpty()) {
+                if (failState == FailState.FAILING_FS_OKAY && assignments.isEmpty() && host.countTotalLive() == 0) {
                     // Found no tasks on the failed host, so fail it for real.
                     markHostDead(failedHostUuid);
                     spawn.getSpawnBalancer().fixTasksForFailedHost(

--- a/hydra-main/src/main/java/com/addthis/hydra/job/HostFailWorker.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/HostFailWorker.java
@@ -255,7 +255,7 @@ public class HostFailWorker {
                 List<JobTaskMoveAssignment> assignments = spawn.getSpawnBalancer().pushTasksOffDiskForFilesystemOkayFailure(host, tasksToMove);
                 // Use available task slots to push tasks off the host in question. Not all of these assignments will necessarily be moved.
                 spawn.executeReallocationAssignments(assignments, !diskFull && obeyTaskSlots.get());
-                if (failState == FailState.FAILING_FS_OKAY && assignments.isEmpty() && host.countTotalLive() == 0) {
+                if (failState == FailState.FAILING_FS_OKAY && assignments.isEmpty()) {
                     // Found no tasks on the failed host, so fail it for real.
                     markHostDead(failedHostUuid);
                     spawn.getSpawnBalancer().fixTasksForFailedHost(


### PR DESCRIPTION
We recently noticed that the fs-ok minion failure queue was being blocked by errored jobs on the hosts being failed.

After running through the debugger and review the code, this appears to be caused by the fs-ok failure reusing logic for normal rebalancing assignments which refuses to move errored tasks.  Since fs-ok failure is supposed to behave similar to normal rebalancing - moving tasks in the background when the cluster has idle task slots - I left this behavior in place.

However, the previous fs-ok failure would only complete the failure once all tasks had been moved off using this rebalancing.  I have changed this condition to fallback to fs-dead failure once only problematic tasks (errored/degraded/etc) remain.

I've tested the change on the test cluster, and it first moved the normal/idle jobs as expected, then performed the typical fs-dead failure by reverting then moving the remaining errored tasks.