### PR TITLE
Donnelly/blocked query metrics

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/query/MeshQueryMaster.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/query/MeshQueryMaster.java
@@ -234,7 +234,7 @@ public class MeshQueryMaster extends ChannelOutboundHandlerAdapter implements Au
 
         MeshSourceAggregator aggregator = new MeshSourceAggregator(sourcesByTaskID, meshy, this, remoteQuery);
         ctx.pipeline().addLast(ctx.executor(), "query aggregator", aggregator);
-        TrackerHandler trackerHandler = new TrackerHandler(tracker, opsLog);
+        TrackerHandler trackerHandler = new TrackerHandler(tracker, opsLog, aggregator);
         ctx.pipeline().addLast(ctx.executor(), "query tracker", trackerHandler);
         ctx.pipeline().remove(this);
         ctx.pipeline().write(query, promise);

--- a/hydra-main/src/main/java/com/addthis/hydra/query/aggregate/DetailedStatusTask.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/query/aggregate/DetailedStatusTask.java
@@ -29,14 +29,7 @@ public class DetailedStatusTask implements Runnable {
     @Override
     public void run() {
         try {
-            int lines = 0;
-            QueryTaskSource[] taskSources = sourceAggregator.taskSources;
-            TaskSourceInfo[] taskSourceInfos = new TaskSourceInfo[taskSources.length];
-            for (int i = 0; i < taskSources.length; i++) {
-                taskSourceInfos[i] = new TaskSourceInfo(taskSources[i]);
-                lines += taskSources[i].lines;
-            }
-            promise.trySuccess(taskSourceInfos);
+            promise.trySuccess(taskSourceInfo(sourceAggregator));
         } catch (Exception e) {
             promise.tryFailure(e);
         }
@@ -45,5 +38,14 @@ public class DetailedStatusTask implements Runnable {
     public void run(MeshSourceAggregator sourceAggregator) {
         this.sourceAggregator = sourceAggregator;
         run();
+    }
+
+    public static TaskSourceInfo[] taskSourceInfo(MeshSourceAggregator sourceAggregator) {
+        QueryTaskSource[] taskSources = sourceAggregator.taskSources;
+        TaskSourceInfo[] taskSourceInfos = new TaskSourceInfo[taskSources.length];
+        for (int i = 0; i < taskSources.length; i++) {
+            taskSourceInfos[i] = new TaskSourceInfo(taskSources[i]);
+        }
+        return taskSourceInfos;
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/query/tracker/QueryEntry.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/query/tracker/QueryEntry.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.addthis.hydra.data.query.Query;
+import com.addthis.hydra.query.aggregate.MeshSourceAggregator;
 import com.addthis.hydra.query.aggregate.TaskSourceInfo;
 
 import com.google.common.base.Objects;
@@ -30,6 +31,7 @@ public class QueryEntry {
     final int waitTime;
     final String[] opsLog;
     final TrackerHandler trackerHandler;
+    final MeshSourceAggregator aggregator;
 
     long runTime;
     long startTime;
@@ -37,12 +39,13 @@ public class QueryEntry {
     volatile TaskSourceInfo[] lastSourceInfo;
     volatile QueryState queryState = QueryState.AGGREGATING;
 
-    QueryEntry(Query query, String[] opsLog, TrackerHandler trackerHandler) {
+    QueryEntry(Query query, String[] opsLog, TrackerHandler trackerHandler, MeshSourceAggregator aggregator) {
         this.query = query;
         this.opsLog = opsLog;
         this.trackerHandler = trackerHandler;
         this.preOpLines = new AtomicInteger();
         this.postOpLines = new AtomicInteger();
+        this.aggregator = aggregator;
 
         final String timeoutInSeconds = query.getParameter("timeout");
         this.startTime = System.currentTimeMillis();


### PR DESCRIPTION
Ive already tested this on the test cluster and it is working as intended.

I tried to reduce the minimize the amount of code added, rather than optimize it more than necessary.  Namely, the blockedTaskStats method is called twice - once for the number of blocked stats, once for the maximum task wait time.  These gauge metrics are only updated once a minute, only iterate over ~10 queries typically, and are not blocking any important threads.  Thus, I thought the trade off was worth while.