### PR TITLE
addresses replicating-kicking race condition in minion

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/minion/ExecStateException.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/minion/ExecStateException.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.addthis.hydra.minion;
+
+@SuppressWarnings("serial")
+class ExecStateException extends Exception {
+
+    ExecStateException(String msg) {
+        super(msg);
+    }
+}

--- a/hydra-main/src/main/java/com/addthis/hydra/minion/JobTask.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/minion/JobTask.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.function.Function;
 
 import com.addthis.basis.util.LessBytes;
 import com.addthis.basis.util.LessFiles;
@@ -752,9 +753,13 @@ public class JobTask implements Codable {
         return backups.get(offset);
     }
 
-    private void require(boolean test, String msg) throws ExecException {
+    private void require(boolean test, String msg) throws Exception {
+        require(test, msg, ExecException::new);
+    }
+
+    private void require(boolean test, String msg, Function<String,Exception> exceptionType) throws Exception {
         if (!test) {
-            throw new ExecException(msg);
+            throw exceptionType.apply(msg);
         }
     }
 
@@ -789,7 +794,7 @@ public class JobTask implements Codable {
             String jobId = kickMessage.getJobUuid();
             int jobNode = kickMessage.getJobKey().getNodeNumber();
             log.debug("[task.exec] {}", kickMessage.getJobKey());
-            require(testTaskIdle(), "task is not idle");
+            require(testTaskIdle(), "task is not idle", ExecStateException::new);
             String jobCommand = kickMessage.getCommand();
             require(!LessStrings.isEmpty(jobCommand), "task command is missing or empty");
             // ensure we're not changing something critical on a re-spawn

--- a/hydra-main/src/main/java/com/addthis/hydra/minion/Minion.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/minion/Minion.java
@@ -433,11 +433,9 @@ public class Minion implements MessageListener<CoreMessage>, Codable, AutoClosea
                 capacityLock.lock();
                 try {
                     boolean lackCap = activeTaskKeys.size() >= maxActiveTasks;
-                    Runnable rejectTask = () -> { sendStatusMessage(new StatusTaskCantBegin(getUUID(),
-                            nextKick.getJobUuid(), nextKick.getNodeID(), nextKick.getPriority()));
-                    };
                     if (lackCap) {
-                        rejectTask.run();
+                        sendStatusMessage(new StatusTaskCantBegin(getUUID(), nextKick.getJobUuid(),
+                                nextKick.getNodeID(), nextKick.getPriority()));
                         jobQueue.remove(nextKick);
                         break;
                     } else {
@@ -452,7 +450,8 @@ public class Minion implements MessageListener<CoreMessage>, Codable, AutoClosea
                             task.exec(nextKick, true);
                         } catch (ExecStateException ex) {
                             log.warn("[kick] failed to kick non-idle task {}", task.getName(), ex);
-                            rejectTask.run();
+                            sendStatusMessage(new StatusTaskCantBegin(getUUID(), nextKick.getJobUuid(),
+                                    nextKick.getNodeID(), nextKick.getPriority()));
                         } catch (Exception ex) {
                             log.warn("[kick] exception while trying to kick {}", task.getName(), ex);
                             task.sendEndStatus(JobTaskErrorCode.EXIT_SCRIPT_EXEC_ERROR);

--- a/hydra-main/src/main/java/com/addthis/hydra/minion/Minion.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/minion/Minion.java
@@ -100,6 +100,7 @@ import com.rabbitmq.client.Connection;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.Meter;
 import com.yammer.metrics.core.Timer;
 
 import org.apache.curator.framework.CuratorFramework;
@@ -178,6 +179,7 @@ public class Minion implements MessageListener<CoreMessage>, Codable, AutoClosea
     Timer fileStatsTimer;
     Counter sendStatusFailCount;
     Counter sendStatusFailAfterRetriesCount;
+    Meter nonIdleIgnoredKicks;
     final int replicateCommandDelaySeconds = Parameter.intValue("replicate.cmd.delay.seconds", 0);
     final int backupCommandDelaySeconds = Parameter.intValue("backup.cmd.delay.seconds", 0);
 
@@ -265,6 +267,7 @@ public class Minion implements MessageListener<CoreMessage>, Codable, AutoClosea
         sendStatusFailAfterRetriesCount = Metrics.newCounter(Minion.class,
                                                              "sendStatusFailAfterRetries-" + getJettyPort() +
                                                              "-JMXONLY");
+        nonIdleIgnoredKicks = Metrics.newMeter(Minion.class, "nonIdleIgnoredKicks", "ignored-kick", TimeUnit.MINUTES);
         fileStatsTimer = Metrics.newTimer(Minion.class, "JobTask-byte-size-timer");
         metricsHandler = MetricsServletMaker.makeHandler();
         activeTaskHistogram = Metrics.newHistogram(Minion.class, "activeTasks");
@@ -450,8 +453,12 @@ public class Minion implements MessageListener<CoreMessage>, Codable, AutoClosea
                             task.exec(nextKick, true);
                         } catch (ExecStateException ex) {
                             log.warn("[kick] failed to kick non-idle task {}", task.getName(), ex);
-                            sendStatusMessage(new StatusTaskCantBegin(getUUID(), nextKick.getJobUuid(),
-                                    nextKick.getNodeID(), nextKick.getPriority()));
+                            // It should be okay to simply ignore non-idle kicks, since the actual task state has already
+                            // been sent back to spawn.
+                            // These ignored kicks are only expected to happen due to a race condition during failing
+                            // minions.  The below metric can be removed once we confirm that ignored kicks are not
+                            // happening when unexpected.
+                            nonIdleIgnoredKicks.mark();
                         } catch (Exception ex) {
                             log.warn("[kick] exception while trying to kick {}", task.getName(), ex);
                             task.sendEndStatus(JobTaskErrorCode.EXIT_SCRIPT_EXEC_ERROR);


### PR DESCRIPTION
Currently, failing a minion triggers a large number of replicating tasks, many which become errored due to failed kicks.
I believe this is due to a race condition where the kick message is sent to spawn while the task is idle, then a minion
failure causes spawn to send a task-replicate message to the same minion before the kick message in processesd, the minion
handles the replicate message, finally the minion tries to handle the kick message but fails because the task isnt idle.
This change essentially demotes the non-idle failure to a warning, similar to the minions response when it tries to kick
a task it doesnt have run-capacity for.