### PR TITLE
First pass of job lock usage review

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/job/Job.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/Job.java
@@ -577,6 +577,7 @@ public final class Job implements IJob {
         return ImmutableList.copyOf(nodes);
     }
 
+    // FIXME must be synchronized - iterating over nodes is not thread-safe
     public List<JobTask> getCopyOfTasksSorted() {
         if (nodes == null) {
             nodes = new ArrayList<>();

--- a/hydra-main/src/main/java/com/addthis/hydra/job/JobExpand.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/JobExpand.java
@@ -13,6 +13,8 @@
  */
 package com.addthis.hydra.job;
 
+import javax.annotation.Nonnull;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -22,8 +24,8 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import com.addthis.basis.net.HttpUtil;
-import com.addthis.basis.util.Parameter;
 import com.addthis.basis.util.LessStrings;
+import com.addthis.basis.util.Parameter;
 import com.addthis.basis.util.TokenReplacer;
 import com.addthis.basis.util.TokenReplacerOverflowException;
 
@@ -33,7 +35,6 @@ import com.addthis.hydra.data.util.CommentTokenizer;
 import com.addthis.hydra.job.alias.AliasManager;
 import com.addthis.hydra.job.entity.JobEntityManager;
 import com.addthis.hydra.job.entity.JobMacro;
-import com.addthis.hydra.job.entity.JobMacroManager;
 import com.addthis.hydra.job.spawn.Spawn;
 
 import com.google.common.base.Joiner;
@@ -42,8 +43,6 @@ import com.google.common.collect.Lists;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
 
 public class JobExpand {
 
@@ -314,6 +313,7 @@ public class JobExpand {
                 List<String> mfn = Lists.newArrayList(Splitter.on(' ').split(label));
                 String macroName = mfn.get(0);
                 List<String> tokens = mfn.subList(1, mfn.size());
+                // TODO delete jobhosts handling - it's only used in old macros that are not used by any job
                 if (macroName.equals("jobhosts")) {
                     JobMacro macro = spawn.createJobHostMacro(tokens.get(0), Integer.parseInt(tokens.get(1)));
                     return macro.getMacro();

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/JobRekickTask.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/JobRekickTask.java
@@ -41,6 +41,7 @@ class JobRekickTask implements Runnable {
             try {
                 if (!spawn.getSystemManager().isQuiesced()) {
                     String[] jobids = null;
+                    // Not needed
                     spawn.acquireJobLock();
                     try {
                         jobids = new String[spawn.spawnState.jobs.size()];

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/ScheduledTaskKick.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/ScheduledTaskKick.java
@@ -71,6 +71,7 @@ public class ScheduledTaskKick implements Runnable {
             }
         } catch (Exception e) {
             log.warn("failed to kick job {} task {} on host {}", jobId, kick.getNodeID(), kick.getHostUuid(), e);
+            // Maybe
             spawn.acquireJobLock();
             try {
                 job.errorTask(task, JobTaskErrorCode.KICK_ERROR);

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/UpdateEventRunnable.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/UpdateEventRunnable.java
@@ -52,6 +52,7 @@ class UpdateEventRunnable implements Runnable {
         int taskQueuedNoSlot = 0;
         long files = 0;
         long bytes = 0;
+        // Why?
         spawn.acquireJobLock();
         try {
             for (Job job : spawn.spawnState.jobs.values()) {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
@@ -808,6 +808,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
 
     private List<JobTask> findAllTasksAssignedToHost(String failedHostUUID) {
         List<JobTask> rv = new ArrayList<>();
+        // Why?
         spawn.acquireJobLock();
         try {
             for (Job job : spawn.listJobs()) {
@@ -1384,6 +1385,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
         List<JobTaskMoveAssignment> rv = purgeMisplacedTasks(host, 1);
         String hostID = host.getHostUuid();
         for (String jobID : activeJobs) {
+            // Maybe
             spawn.acquireJobLock();
             try {
                 Job job = spawn.getJob(jobID);

--- a/hydra-main/src/main/java/com/addthis/hydra/job/web/resources/GroupsResource.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/web/resources/GroupsResource.java
@@ -205,6 +205,7 @@ public class GroupsResource {
             }
             Map<String, List<MinimalJob>> quotas = new HashMap<>();
             long totalBytes = 0;
+            // Why?
             spawn.acquireJobLock();
             try {
                 Iterator<Job> jobIterator = spawn.getSpawnState().jobsIterator();


### PR DESCRIPTION
This is not a PR in the typical sense. The changes are all comments as the result of my review of all Spawn.jobLock usage. The necessity of many are questionable to me. My main question is the intent of the jobLock in the first place: is it to guard against concurrent modification to `SpawnState.jobs` map, to individual jobs, or to tasks? Based on current code base, it's being used rather liberally for all of those and more. History may also be a factor: `SpawnState.jobs` is a `ConcurrentHashMap`, so some of the locks are obviously unnecessary, but `jobs` might have been a regular Map at one time such that the locks were required? I want to understand if I'm missing something important. This is my attempt at a collaborative code review to get other more knowledgable developers to comment.

Usages that I'm rather certain to be unnecessary are marked as "Not needed" - I could be wrong. Usages that I'm unsure are marked as "Maybe". All inputs are welcome.