### PR TITLE
Rebalance when busy, make min free disk absolute

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/HostState.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/HostState.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import com.addthis.hydra.minion.Minion;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -403,10 +404,17 @@ public class HostState implements HostMessage {
     }
 
     public double getDiskUsedPercentModified(long reduce) {
+        Preconditions.checkArgument(reduce >= 0, "reduce must be non-negative");
         if ((max == null) || (used == null) || (max.getDisk() <= 0)) {
             return 0;
         }
-        return (double) (used.getDisk() / (max.getDisk() - reduce));
+        double value = (double) (used.getDisk() / (max.getDisk() - reduce));
+        if (value < 0) {
+            return 0;
+        } else if (value > 1) {
+            return 1;
+        }
+        return value;
     }
 
     public void setDead(boolean dead) {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/mq/HostState.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/mq/HostState.java
@@ -391,6 +391,24 @@ public class HostState implements HostMessage {
         this.max = max;
     }
 
+    public long getAvailDiskBytes() {
+        if ((max == null) || (used == null)) {
+            return 1; // Fix some tests
+        }
+        return max.getDisk() - used.getDisk();
+    }
+
+    public double getDiskUsedPercent() {
+        return getDiskUsedPercentModified(0);
+    }
+
+    public double getDiskUsedPercentModified(long reduce) {
+        if ((max == null) || (used == null) || (max.getDisk() <= 0)) {
+            return 0;
+        }
+        return (double) (used.getDisk() / (max.getDisk() - reduce));
+    }
+
     public void setDead(boolean dead) {
         this.dead = dead;
     }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
@@ -1244,6 +1244,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
 
     private HostScore calculateHostScore(HostState host, double clusterMaxMeanActive, double clusterMaxDiskUsed) {
         double meanActive = host.getMeanActiveTasks();
+        // Get percentage of allowed disk space used (max - min free space = allowed)
         double diskUsedPercentModified = host.getDiskUsedPercentModified(config.getMinFreeDiskSpaceToRunJobs());
         int activeTaskWeight = config.getActiveTaskWeight();
         int diskUsedWeight = config.getDiskUsedWeight();

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
@@ -157,8 +157,8 @@ public class SpawnBalancer implements Codable, AutoCloseable {
         };
         hostStateReplicationSuitabilityComparator = (hostState, hostState1) -> {
             // Treat recently-replicated-to hosts as having fewer than their reported available bytes
-            long availBytes = getAvailDiskBytes(hostState);
-            long availBytes1 = getAvailDiskBytes(hostState1);
+            long availBytes = hostState.getAvailDiskBytes();
+            long availBytes1 = hostState1.getAvailDiskBytes();
             if (recentlyReplicatedToHosts.getIfPresent(hostState.getHostUuid()) != null) {
                 availBytes /= 2;
             }
@@ -219,13 +219,6 @@ public class SpawnBalancer implements Codable, AutoCloseable {
         } else {
             return config.getDefaultHostScore();
         }
-    }
-
-    private static long getAvailDiskBytes(HostState host) {
-        if ((host.getMax() == null) || (host.getUsed() == null)) {
-            return 1; // Fix some tests
-        }
-        return host.getMax().getDisk() - host.getUsed().getDisk();
     }
 
     /** Start a thread that will perform autobalancing in the background if appropriate to do so */
@@ -377,8 +370,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
         if (spawn.getHostFailWorker().getFailureState(host.getHostUuid()) != HostFailWorker.FailState.ALIVE) {
             return false;
         }
-        return host.canMirrorTasks() &&
-               (getUsedDiskPercent(host) < (1 - config.getMinDiskPercentAvailToReceiveNewTasks()));
+        return host.canMirrorTasks() && (host.getAvailDiskBytes() > config.getMinFreeDiskSpaceToRecieveNewTasks());
     }
 
     /**
@@ -412,13 +404,6 @@ public class SpawnBalancer implements Codable, AutoCloseable {
             rv.put(task, hostIterator.next());
         }
         return rv;
-    }
-
-    private static double getUsedDiskPercent(HostState host) {
-        if ((host.getMax() == null) || (host.getUsed() == null) || (host.getMax().getDisk() <= 0)) {
-            return 0;
-        }
-        return (double) host.getUsed().getDisk() / host.getMax().getDisk();
     }
 
     public List<JobTaskMoveAssignment> pushTasksOffDiskForFilesystemOkayFailure(HostState host, int moveLimit) {
@@ -619,7 +604,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
             return false;
         }
         /* try not to put a task on a host if it would almost fill the host */
-        if (taskSizer.estimateTrueSize(task) > (config.getHostDiskFactor() * getAvailDiskBytes(hostCandidate))) {
+        if (taskSizer.estimateTrueSize(task) > (config.getHostDiskFactor() * hostCandidate.getAvailDiskBytes())) {
             return false;
         }
         return true;
@@ -631,11 +616,10 @@ public class SpawnBalancer implements Codable, AutoCloseable {
      * @return True if it is okay to autobalance
      */
     public boolean okayToAutobalance() {
-        // Don't autobalance if it is disabled, spawn is quiesced, the failure queue is non-empty, or the number of queued tasks is high
+        // Don't autobalance if it is disabled, spawn is quiesced, or the failure queue is non-empty
         if ((config.getAutoBalanceLevel() == 0) ||
             spawn.getSystemManager().isQuiesced() ||
-            spawn.getHostFailWorker().queuedHosts().size() > 0 ||
-            (spawn.getLastQueueSize() > hostManager.listHostStatus(null).size())) {
+            spawn.getHostFailWorker().queuedHosts().size() > 0) {
             return false;
         }
         // Don't autobalance if there are still jobs in rebalance state
@@ -772,7 +756,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
             }
             for (HostState host : hostManager.listHostStatus(job.getMinionType())) {
                 if (host.isUp() && !host.isDead()) {
-                    double availDisk = 1 - getUsedDiskPercent(host);
+                    double availDisk = 1 - host.getDiskUsedPercent();
                     rv.put(host.getHostUuid(), addOrIncrement(rv.get(host.getHostUuid()), availDisk));
                 }
             }
@@ -1044,7 +1028,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
         HostFailWorker.FailState failState = spawn.getHostFailWorker().getFailureState(hostID);
         int numAlleviateHosts = (int) Math.ceil(sortedHosts.size() * config.getAlleviateHostPercentage());
         if ((failState == HostFailWorker.FailState.FAILING_FS_OKAY) || isExtremeHost(hostID, true, true) ||
-            (getUsedDiskPercent(host) > (1 - config.getMinDiskPercentAvailToReceiveNewTasks()))) {
+            (host.getAvailDiskBytes() > config.getMinFreeDiskSpaceToRecieveNewTasks())) {
             // Host disk is overloaded
             log.info("[spawn.balancer] {} categorized as overloaded host; looking for tasks to push off of it", hostID);
             List<HostState> lightHosts = sortedHosts.subList(0, numAlleviateHosts);
@@ -1075,8 +1059,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
     public List<HostState> sortHostsByActiveTasks(Collection<HostState> hosts) {
         List<HostState> hostList = new ArrayList<>(hosts);
         removeDownHosts(hostList);
-        Collections.sort(hostList, (hostState, hostState1) ->
-                Double.compare(countTotalActiveTasksOnHost(hostState), countTotalActiveTasksOnHost(hostState1)));
+        Collections.sort(hostList, Comparator.comparingDouble(this::countTotalActiveTasksOnHost));
         return hostList;
     }
 
@@ -1193,11 +1176,15 @@ public class SpawnBalancer implements Codable, AutoCloseable {
      * @param host The host to check
      * @return True if the disk is nearly full
      */
-    public boolean isDiskFull(HostState host) {
-        boolean full = (host != null) && (getUsedDiskPercent(host) > (1 - config.getMinDiskPercentAvailToRunJobs()));
+    public boolean isDiskFull(@Nullable HostState host) {
+        if (host == null) {
+            return false;
+        }
+        long freeSpace = host.getAvailDiskBytes();
+        boolean full = freeSpace <= config.getMinFreeDiskSpaceToRunJobs();
         if (full) {
-            log.warn("[spawn.balancer] Host {} with uuid {} is nearly full, with used disk {}", host.getHost(),
-                     host.getHostUuid(), getUsedDiskPercent(host));
+            log.warn("[spawn.balancer] Host {} with uuid {} is nearly full, with {} GB free disk space", host.getHost(),
+                     host.getHostUuid(), freeSpace / 1_000_000_000);
         }
         return full;
     }
@@ -1220,7 +1207,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
             double sumTaskPercent = 0;
             for (HostState host : hosts) {
                 maxMeanActive = Math.max(maxMeanActive, host.getMeanActiveTasks());
-                double diskPercentUsed = getUsedDiskPercent(host);
+                double diskPercentUsed = host.getDiskUsedPercent();
                 sumDiskPercentUsed += diskPercentUsed;
                 maxDiskPercentUsed = Math.max(diskPercentUsed, maxDiskPercentUsed);
                 minDiskPercentUsed = Math.min(diskPercentUsed, minDiskPercentUsed);
@@ -1239,7 +1226,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
                 cachedHostScores.put(host.getHostUuid(), score);
 
                 // update average metrics
-                double diskDiff = Math.abs(avgDiskPercentUsed - getUsedDiskPercent(host));
+                double diskDiff = Math.abs(avgDiskPercentUsed - host.getDiskUsedPercent());
                 sumDiskPercentUsedDiff += diskDiff;
                 double taskDiff = cachedHostScores.get(host.getHostUuid()).getScoreValue(false);
                 sumTaskPercentDiff += Math.abs(avgTaskPercent - taskDiff);
@@ -1256,26 +1243,18 @@ public class SpawnBalancer implements Codable, AutoCloseable {
     }
 
     private HostScore calculateHostScore(HostState host, double clusterMaxMeanActive, double clusterMaxDiskUsed) {
-        double score = 0;
         double meanActive = host.getMeanActiveTasks();
-        double usedDiskPercent = getUsedDiskPercent(host);
-        // If either metric is zero across the whole cluster, treat every host as having full load in that aspect
-        if (clusterMaxMeanActive <= 0) {
-            meanActive = 1;
-            clusterMaxMeanActive = 1;
-        }
-        if (clusterMaxDiskUsed <= 0) {
-            usedDiskPercent = 1;
-            clusterMaxDiskUsed = 1;
-        }
+        double diskUsedPercentModified = host.getDiskUsedPercentModified(config.getMinFreeDiskSpaceToRunJobs());
         int activeTaskWeight = config.getActiveTaskWeight();
         int diskUsedWeight = config.getDiskUsedWeight();
         // Assemble the score as a combination of the mean active tasks and the disk used
-        score += activeTaskWeight * Math.pow(meanActive / clusterMaxMeanActive, 2.5);
-        score += diskUsedWeight * Math.pow(usedDiskPercent / clusterMaxDiskUsed, 2.5);
+        double exponent = 2.5;
+        double score = activeTaskWeight * Math.pow(meanActive, exponent);
+        double diskPercentPowered = Math.pow(diskUsedPercentModified, exponent);
+        score += diskUsedWeight * diskPercentPowered;
         // If host is very full, make sure to give the host a big score
-        score = Math.max(score, (activeTaskWeight + diskUsedWeight) * usedDiskPercent);
-        return new HostScore(meanActive, usedDiskPercent, score);
+        score = Math.max(score, (activeTaskWeight + diskUsedWeight) * diskPercentPowered);
+        return new HostScore(meanActive, diskUsedPercentModified, score);
     }
 
     /**

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
@@ -176,8 +176,8 @@ public class SpawnBalancer implements Codable, AutoCloseable {
         SpawnBalancer.makeGauge("maxDiskPercentUsedDiff", () -> maxDiskPercentUsedDiff);
         SpawnBalancer.makeGauge("avgDiskPercentUsedDiff", () -> avgDiskPercentUsedDiff);
         SpawnBalancer.makeGauge("minTaskPercentDiff", () -> minTaskPercentDiff);
-        SpawnBalancer.makeGauge("minTaskPercentDiff", () -> minTaskPercentDiff);
-        SpawnBalancer.makeGauge("minTaskPercentDiff", () -> minTaskPercentDiff);
+        SpawnBalancer.makeGauge("maxTaskPercentDiff", () -> maxTaskPercentDiff);
+        SpawnBalancer.makeGauge("avgTaskPercentDiff", () -> avgTaskPercentDiff);
     }
 
     private static <T> void makeGauge(String name, Supplier<T> value) {
@@ -1228,7 +1228,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
                 // update average metrics
                 double diskDiff = Math.abs(avgDiskPercentUsed - host.getDiskUsedPercent());
                 sumDiskPercentUsedDiff += diskDiff;
-                double taskDiff = cachedHostScores.get(host.getHostUuid()).getScoreValue(false);
+                double taskDiff = score.getScoreValue(false);
                 sumTaskPercentDiff += Math.abs(avgTaskPercent - taskDiff);
             }
             avgDiskPercentUsedDiff = sumDiskPercentUsedDiff / (double) numScores;

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerConfig.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerConfig.java
@@ -72,10 +72,10 @@ public class SpawnBalancerConfig implements Codable {
     // Track the last time a job autobalance was done
     private long lastJobAutobalanceTime = 0L;
 
-    // If you're at more than 80% disk capacity, you don't get assigned any new tasks or replicas
-    private double minDiskPercentAvailToReceiveNewTasks = Double.parseDouble(Parameter.value("spawnbalance.min.disk.percent.avail.newtasks", ".2"));
-    // If you're at more than 90% disk capacity, push tasks off before running additional tasks
-    private double minDiskPercentAvailToRunJobs = Double.parseDouble(Parameter.value("spawnbalance.min.disk.percent.avail.runtasks", ".1"));
+    // If you have less than 700GB free disk space, push tasks off before running additional tasks
+    private long minFreeDiskSpaceToRecieveNewTasks = Parameter.longValue("spawnbalance.disk.free.newtasks", 700_000_000_000L);
+    // If you have less than 350GB free disk space, push tasks off before running additional tasks
+    private long minFreeDiskSpaceToRunJobs = Parameter.longValue("spawnbalance.disk.free.runjobs", 350_000_000_000L);
     // Max number of read-only-replicas for a given host
     private int maxReadonlyReplicas = Parameter.intValue("spawnbalance.max.job.task.replicas.per.host", 5);
 
@@ -192,20 +192,20 @@ public class SpawnBalancerConfig implements Codable {
         this.lastJobAutobalanceTime = lastJobAutobalanceTime;
     }
 
-    public double getMinDiskPercentAvailToReceiveNewTasks() {
-        return minDiskPercentAvailToReceiveNewTasks;
+    public long getMinFreeDiskSpaceToRecieveNewTasks() {
+        return minFreeDiskSpaceToRecieveNewTasks;
     }
 
-    public void setMinDiskPercentAvailToReceiveNewTasks(double minDiskPercentAvailToReceiveNewTasks) {
-        this.minDiskPercentAvailToReceiveNewTasks = minDiskPercentAvailToReceiveNewTasks;
+    public void setMinFreeDiskSpaceToRecieveNewTasks(long minFreeDiskSpaceToRecieveNewTasks) {
+        this.minFreeDiskSpaceToRecieveNewTasks = minFreeDiskSpaceToRecieveNewTasks;
     }
 
-    public double getMinDiskPercentAvailToRunJobs() {
-        return minDiskPercentAvailToRunJobs;
+    public long getMinFreeDiskSpaceToRunJobs() {
+        return minFreeDiskSpaceToRunJobs;
     }
 
-    public void setMinDiskPercentAvailToRunJobs(double minDiskPercentAvailToRunJobs) {
-        this.minDiskPercentAvailToRunJobs = minDiskPercentAvailToRunJobs;
+    public void setMinFreeDiskSpaceToRunJobs(long minFreeDiskSpaceToRunJobs) {
+        this.minFreeDiskSpaceToRunJobs = minFreeDiskSpaceToRunJobs;
     }
 
     public int getMaxReadonlyReplicas() {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerConfig.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerConfig.java
@@ -72,7 +72,7 @@ public class SpawnBalancerConfig implements Codable {
     // Track the last time a job autobalance was done
     private long lastJobAutobalanceTime = 0L;
 
-    // If you have less than 700GB free disk space, push tasks off before running additional tasks
+    // If you have less than 700GB free disk space, you don't get assigned any new tasks or replicas
     private long minFreeDiskSpaceToRecieveNewTasks = Parameter.longValue("spawnbalance.disk.free.newtasks", 700_000_000_000L);
     // If you have less than 350GB free disk space, push tasks off before running additional tasks
     private long minFreeDiskSpaceToRunJobs = Parameter.longValue("spawnbalance.disk.free.runjobs", 350_000_000_000L);

--- a/hydra-uber/bin/local-stack.sh
+++ b/hydra-uber/bin/local-stack.sh
@@ -137,8 +137,8 @@ export MINION_OPT="${LOG4J_PROPERTIES} -Xmx512M -Dminion.mem=512 -Dminion.localh
 export SPAWN_OPT="-Xmx512M ${LOG4J_PROPERTIES} -Dspawn.localhost=localhost -Dspawn.queryhost=localhost -Dspawn.status.interval=6000 \
 -Dspawn.chore.interval=3000 -Dhttp.post.max=327680  -Dspawn.polltime=10000 -Dspawnbalance.min.disk.percent.avail.replicas=0.01 \
 -Dspawn.auth.ldap=false -Dmesh.port=5000 -Djob.store.remote=false -Dspawn.queue.new.task.last.slot.delay=0 -Dspawn.defaultReplicaCount=0 \
--Dspawnbalance.min.disk.percent.avail.newtasks=0.05 \
--Dspawnbalance.min.disk.percent.avail.runtasks=0.05 \
+-Dspawnbalance.disk.free.newtasks=20000000000 \
+-Dspawnbalance.disk.free.runjobs=20000000000 \
 -Dbatch.brokerAddresses=localhost -Dcom.addthis.hydra.job.web.SpawnServiceConfiguration.keyStorePassword=$HYDRA_LOCAL_DIR/cert/keystore.password \
 -Dcom.addthis.hydra.job.web.SpawnServiceConfiguration.keyManagerPassword=$HYDRA_LOCAL_DIR/cert/keystore.password \
 -Dcom.addthis.hydra.job.web.SpawnServiceConfiguration.keyStorePath=$HYDRA_LOCAL_DIR/cert/keystore.jks \


### PR DESCRIPTION
These are some quick fixes to make rebalancing keep up better and clean up some code.

- change disk free space to force rebalance or not allow new tasks from percent to absolute numbers
- change host score equation to not include cluster max values, each host’s score is independent
- move some methods inside of hostscore: getDiskUsedPercent, getAvailDiskBytes