### PR TITLE
reduce default disk free; update unit tests

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerConfig.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerConfig.java
@@ -72,10 +72,10 @@ public class SpawnBalancerConfig implements Codable {
     // Track the last time a job autobalance was done
     private long lastJobAutobalanceTime = 0L;
 
-    // If you have less than 700GB free disk space, you don't get assigned any new tasks or replicas
-    private long minFreeDiskSpaceToRecieveNewTasks = Parameter.longValue("spawnbalance.disk.free.newtasks", 700_000_000_000L);
-    // If you have less than 350GB free disk space, push tasks off before running additional tasks
-    private long minFreeDiskSpaceToRunJobs = Parameter.longValue("spawnbalance.disk.free.runjobs", 350_000_000_000L);
+    // If you have less than this many bytes of free disk space, you don't get assigned any new tasks or replicas
+    private long minFreeDiskSpaceToRecieveNewTasks = Parameter.longValue("spawnbalance.disk.free.newtasks", 20_000_000_000L);
+    // If you have less than this many bytes of free disk space, push tasks off before running additional tasks
+    private long minFreeDiskSpaceToRunJobs = Parameter.longValue("spawnbalance.disk.free.runjobs", 10_000_000_000L);
     // Max number of read-only-replicas for a given host
     private int maxReadonlyReplicas = Parameter.intValue("spawnbalance.max.job.task.replicas.per.host", 5);
 

--- a/hydra-main/src/test/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerTest.java
+++ b/hydra-main/src/test/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerTest.java
@@ -141,8 +141,8 @@ public class SpawnBalancerTest extends ZkCodecStartUtil {
             String hostID = "light" + i;
             hostIDs.add(hostID);
             HostState lightHost = installHostStateWithUUID(hostID, spawn, true);
-            lightHost.setUsed(new HostCapacity(0, 0, 0, 200_000_000_000L));
-            lightHost.setMax(new HostCapacity(0, 0, 0, 1_000_000_000_000L));
+            lightHost.setUsed(new HostCapacity(0, 0, 0, 20_000_000_000L));
+            lightHost.setMax(new HostCapacity(0, 0, 0, 100_000_000_000L));
         }
         Job job = createJobAndUpdateHosts(spawn, numLightHosts + 1, hostIDs, now, 1000, 0);
         job.setReplicas(1);
@@ -315,18 +315,18 @@ public class SpawnBalancerTest extends ZkCodecStartUtil {
         HostState readOnlyHost = installHostStateWithUUID(readOnlyHostUUID, spawn, true, true, 0, "default");
         List<HostState> hosts = Arrays.asList(heavyHost, lightHost, lightHost2, readOnlyHost);
         spawn.getJobCommandManager().putEntity("foo", new JobCommand(), false);
-        Job gargantuanJob = createSpawnJob(spawn, 1, Arrays.asList(heavyHostUUID), now, 8_000_000_000_000L, 0);
+        Job gargantuanJob = createSpawnJob(spawn, 1, Arrays.asList(heavyHostUUID), now, 80_000_000_000L, 0);
         Job movableJob1 = createSpawnJob(spawn, 1, Arrays.asList(heavyHostUUID), now, 850_000_000L, 0);
         Job movableJob2 = createSpawnJob(spawn, 1, Arrays.asList(heavyHostUUID), now, 820_000_000L, 0);
         heavyHost.setStopped(simulateJobKeys(gargantuanJob, movableJob1, movableJob2));
-        heavyHost.setMax(new HostCapacity(10, 10, 10, 10_000_000_000_000L));
-        heavyHost.setUsed(new HostCapacity(10, 10, 10, 9_900_000_000_000L));
-        lightHost.setMax(new HostCapacity(10, 10, 10, 10_000_000_000_000L));
-        lightHost.setUsed(new HostCapacity(10, 10, 10, 20_000_000_0000L));
-        lightHost2.setMax(new HostCapacity(10, 10, 10, 10_000_000_000_000L));
-        lightHost2.setUsed(new HostCapacity(10, 10, 10, 20_000_000_000L));
-        readOnlyHost.setMax(new HostCapacity(10, 10, 10, 10_000_000_000_000L));
-        readOnlyHost.setUsed(new HostCapacity(10, 10, 10, 20_000_000_000L));
+        heavyHost.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
+        heavyHost.setUsed(new HostCapacity(10, 10, 10, 90_900_000_000L));
+        lightHost.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
+        lightHost.setUsed(new HostCapacity(10, 10, 10, 200_000_0000L));
+        lightHost2.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
+        lightHost2.setUsed(new HostCapacity(10, 10, 10, 200_000_000L));
+        readOnlyHost.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
+        readOnlyHost.setUsed(new HostCapacity(10, 10, 10, 200_000_000L));
         hostManager.updateHostState(heavyHost);
         hostManager.updateHostState(lightHost);
         hostManager.updateHostState(lightHost2);
@@ -449,12 +449,12 @@ public class SpawnBalancerTest extends ZkCodecStartUtil {
     public void hostScoreTest() throws Exception {
         // Test that heavily-loaded and lightly-loaded hosts are identified as such, and that medium-loaded hosts are
         // not identified as heavy or light
-        long[] used = new long[]{1000_000_000_000L, 9900_000_000_000L, 10000_000_000_000L, 10500_000_000_000L, 20000_000_000_000L};
+        long[] used = new long[]{1_000_000_000L, 99_000_000_000L, 100_000_000_000L, 105_000_000_000L, 200_000_000_000L};
         int i = 0;
         for (long usedVal : used) {
             HostState hostState = installHostStateWithUUID("host" + (i++), spawn, true);
             hostState.setUsed(new HostCapacity(0, 0, 0, usedVal));
-            hostState.setMax(new HostCapacity(0, 0, 0, 25000_000_000_000L));
+            hostState.setMax(new HostCapacity(0, 0, 0, 250_000_000_000L));
         }
         bal.updateAggregateStatistics(hostManager.listHostStatus(null));
         assertTrue("should correctly identify light host", bal.isExtremeHost("host0", true, false));
@@ -568,7 +568,7 @@ public class SpawnBalancerTest extends ZkCodecStartUtil {
         String zkPath = isUp ? "/minion/up/" + hostUUID : "/minion/dead/" + hostUUID;
         zkClient.create().withMode(CreateMode.EPHEMERAL).forPath(zkPath);
         HostState newHostState = new HostState(hostUUID);
-        newHostState.setMax(new HostCapacity(10, 10, 10, 1_000_000_000_000L));
+        newHostState.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
         newHostState.setUsed(new HostCapacity(0, 0, 0, 100));
         newHostState.setHost("hostname-for:" + hostUUID);
         newHostState.setUp(isUp);


### PR DESCRIPTION
Reducing default disk space required to 10/20 GB to run tasks or receive new ones. Configure your local environment differently if desired.