### PR TITLE
Retry HTTPOutputWriter on SocketException

### DIFF
--- a/hydra-task/src/main/java/com/addthis/hydra/task/output/HttpOutputWriter.java
+++ b/hydra-task/src/main/java/com/addthis/hydra/task/output/HttpOutputWriter.java
@@ -20,6 +20,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -146,6 +147,7 @@ public class HttpOutputWriter extends AbstractOutputWriter {
         RetryerBuilder<Integer> retryerBuilder = RetryerBuilder
                 .<Integer>newBuilder()
                 .retryIfExceptionOfType(NoHttpResponseException.class)
+                .retryIfExceptionOfType(SocketException.class)
                 .retryIfResult((val) -> (val == null) || !(val >= 200 && val < 300))
                 .withStopStrategy(StopStrategies.stopAfterAttempt(retries));
         if (backoffMax > 0) {


### PR DESCRIPTION
We get a SocketException in the http output writer threads whenever ops changes the load-balancer configuration. Unfortunately, this causes the job to immediately error.

This PR simply adds SocketException to the list of retry-able exceptions.

It is valid to simply call 'retryIfExceptionOfType` multiple times -- it gets 'or'-ed in, as opposed to overwriting a variable or something.

```    public RetryerBuilder<V> retryIfExceptionOfType(@Nonnull Class<? extends Throwable> exceptionClass) {
        Preconditions.checkNotNull(exceptionClass, "exceptionClass may not be null");
        rejectionPredicate = Predicates.or(rejectionPredicate, new ExceptionClassPredicate<V>(exceptionClass));
        return this;
    }
```