### PR TITLE
fix light host rebalance and add unit test

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/Spawn.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/Spawn.java
@@ -1237,7 +1237,6 @@ public class Spawn implements Codable, AutoCloseable {
                     TaskMover tm = new TaskMover(this, hostManager, key, targetHostID, sourceHostID);
                     if (tm.execute()) {
                         hostsAlreadyMovingTasks.add(task.getHostUUID());
-                        jobsNeedingUpdate.add(task.getJobUUID());
                         executedAssignments.add(assignment);
                     }
                 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/Spawn.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/Spawn.java
@@ -1237,6 +1237,7 @@ public class Spawn implements Codable, AutoCloseable {
                     TaskMover tm = new TaskMover(this, hostManager, key, targetHostID, sourceHostID);
                     if (tm.execute()) {
                         hostsAlreadyMovingTasks.add(task.getHostUUID());
+                        jobsNeedingUpdate.add(task.getJobUUID());
                         executedAssignments.add(assignment);
                     }
                 }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/MoveAssignmentList.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/MoveAssignmentList.java
@@ -14,9 +14,9 @@
 package com.addthis.hydra.job.spawn.balancer;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import com.addthis.hydra.job.JobTaskMoveAssignment;
+import com.addthis.hydra.job.mq.JobKey;
 import com.addthis.hydra.job.spawn.Spawn;
 
 class MoveAssignmentList extends ArrayList<JobTaskMoveAssignment> {
@@ -38,10 +38,13 @@ class MoveAssignmentList extends ArrayList<JobTaskMoveAssignment> {
         return super.add(assignment);
     }
 
-    public void addAll(List<JobTaskMoveAssignment> assignments){
-        for(JobTaskMoveAssignment assignment: assignments) {
-            add(assignment);
+    public boolean contains(JobKey jobKey) {
+        for (JobTaskMoveAssignment assignment : this) {
+            if(assignment.getJobKey().getJobUuid().equals(jobKey.getJobUuid())) {
+                return true;
+            }
         }
+        return false;
     }
 
     public long getBytesUsed() {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/MoveAssignmentList.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/MoveAssignmentList.java
@@ -21,7 +21,6 @@ import com.addthis.hydra.job.spawn.Spawn;
 
 class MoveAssignmentList {
     private List<JobTaskMoveAssignment> moveAssignmentList;
-    private static final long serialVersionUID = -563719566151798849L;
 
     private final Spawn spawn;
     private final SpawnBalancerTaskSizer taskSizer;

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/MoveAssignmentList.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/MoveAssignmentList.java
@@ -14,6 +14,7 @@
 package com.addthis.hydra.job.spawn.balancer;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import com.addthis.hydra.job.JobTaskMoveAssignment;
 import com.addthis.hydra.job.spawn.Spawn;
@@ -35,6 +36,12 @@ class MoveAssignmentList extends ArrayList<JobTaskMoveAssignment> {
     public boolean add(JobTaskMoveAssignment assignment) {
         bytesUsed += taskSizer.estimateTrueSize(spawn.getTask(assignment.getJobKey()));
         return super.add(assignment);
+    }
+
+    public void addAll(List<JobTaskMoveAssignment> assignments){
+        for(JobTaskMoveAssignment assignment: assignments) {
+            add(assignment);
+        }
     }
 
     public long getBytesUsed() {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/MoveAssignmentList.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/MoveAssignmentList.java
@@ -45,16 +45,14 @@ class MoveAssignmentList {
     /**
      * Returns <tt>true</tt> if the list contains a move assignment
      * to move any task associated with the specified job.
-     * @param jobID JobID
+     * @param jobId JobID
      * @return <tt>true</tt> if the list contains an assignment moving any of the job's tasks
      */
-    public boolean containsJob(String jobID) {
-        for (JobTaskMoveAssignment assignment : this.moveAssignmentList) {
-            if(assignment.getJobKey().getJobUuid().equals(jobID)) {
-                return true;
-            }
+    public boolean containsJob(String jobId) {
+        if (jobId == null) {
+            return false;
         }
-        return false;
+        return moveAssignmentList.stream().anyMatch(assignment -> jobId.equals(assignment.getJobKey().getJobUuid()));
     }
 
     public List<JobTaskMoveAssignment> getList() {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/MoveAssignmentList.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/MoveAssignmentList.java
@@ -14,12 +14,13 @@
 package com.addthis.hydra.job.spawn.balancer;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import com.addthis.hydra.job.JobTaskMoveAssignment;
-import com.addthis.hydra.job.mq.JobKey;
 import com.addthis.hydra.job.spawn.Spawn;
 
-class MoveAssignmentList extends ArrayList<JobTaskMoveAssignment> {
+class MoveAssignmentList {
+    private List<JobTaskMoveAssignment> moveAssignmentList;
     private static final long serialVersionUID = -563719566151798849L;
 
     private final Spawn spawn;
@@ -30,21 +31,39 @@ class MoveAssignmentList extends ArrayList<JobTaskMoveAssignment> {
     public MoveAssignmentList(Spawn spawn, SpawnBalancerTaskSizer taskSizer) {
         this.spawn = spawn;
         this.taskSizer = taskSizer;
+        this.moveAssignmentList = new ArrayList<>();
     }
 
-    @Override
-    public boolean add(JobTaskMoveAssignment assignment) {
-        bytesUsed += taskSizer.estimateTrueSize(spawn.getTask(assignment.getJobKey()));
-        return super.add(assignment);
+    public int size() {
+        return this.moveAssignmentList.size();
     }
 
-    public boolean contains(JobKey jobKey) {
-        for (JobTaskMoveAssignment assignment : this) {
-            if(assignment.getJobKey().getJobUuid().equals(jobKey.getJobUuid())) {
+    public boolean isEmpty() {
+        return this.moveAssignmentList.isEmpty();
+    }
+
+    /**
+     * Returns <tt>true</tt> if the list contains a move assignment
+     * to move any task associated with the specified job.
+     * @param jobID JobID
+     * @return <tt>true</tt> if the list contains an assignment moving any of the job's tasks
+     */
+    public boolean containsJob(String jobID) {
+        for (JobTaskMoveAssignment assignment : this.moveAssignmentList) {
+            if(assignment.getJobKey().getJobUuid().equals(jobID)) {
                 return true;
             }
         }
         return false;
+    }
+
+    public List<JobTaskMoveAssignment> getList() {
+        return this.moveAssignmentList;
+    }
+
+    public boolean add(JobTaskMoveAssignment assignment) {
+        bytesUsed += taskSizer.estimateTrueSize(spawn.getTask(assignment.getJobKey()));
+        return this.moveAssignmentList.add(assignment);
     }
 
     public long getBytesUsed() {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/MoveAssignmentList.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/MoveAssignmentList.java
@@ -55,9 +55,9 @@ class MoveAssignmentList {
     public boolean add(JobTaskMoveAssignment assignment) {
         // Check if moveAssignmentList contains an assignment that moves a replica of the task to the same target host
         boolean isJobKeyPresent = this.moveAssignmentList.stream()
-                                                         .anyMatch(moveAssignment ->
-                                                                           moveAssignment.getJobKey().equals(assignment.getJobKey()) &&
-                                                                           moveAssignment.getTargetUUID().equals(assignment.getTargetUUID()));
+                                                         .anyMatch(moveAssignment -> moveAssignment.getJobKey().equals(assignment.getJobKey()) &&
+                                                                                     moveAssignment.getTargetUUID() != null &&
+                                                                                     moveAssignment.getTargetUUID().equals(assignment.getTargetUUID()));
 
         if(!isJobKeyPresent) {
             bytesUsed += taskSizer.estimateTrueSize(spawn.getTask(assignment.getJobKey()));

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
@@ -1044,7 +1044,6 @@ public class SpawnBalancer implements Codable, AutoCloseable {
             log.info("[spawn.balancer] {} categorized as overloaded host; looking for tasks to push off of it", hostID);
             List<HostState> lightHosts = sortedHosts.subList(0, numAlleviateHosts);
             List<JobTaskMoveAssignment> moveAssignments = pushTasksOffHost(host, lightHosts, true, 1, config.getTasksMovedFullRebalance(), true);
-            markRecentlyReplicatedTo(moveAssignments);
             rv.addAll(moveAssignments);
         } else if (isExtremeHost(hostID, true, false)) {
             // Host disk is underloaded
@@ -1052,7 +1051,6 @@ public class SpawnBalancer implements Codable, AutoCloseable {
             List<HostState> heavyHosts =
                     Lists.reverse(sortedHosts.subList(sortedHosts.size() - numAlleviateHosts, sortedHosts.size()));
             List<JobTaskMoveAssignment> moveAssignments = pushTasksOntoHost(host, heavyHosts);
-            markRecentlyReplicatedTo(moveAssignments);
             rv.addAll(moveAssignments);
         } else if (isExtremeHost(hostID, false, true)) {
             // Host is overworked

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
@@ -444,7 +444,8 @@ public class SpawnBalancer implements Codable, AutoCloseable {
                 byteLimit -= taskTrueSize;
             }
         }
-        return moveAssignments;
+        rv.addAll(moveAssignments);
+        return rv;
     }
 
     /* Look through a hoststate to find tasks that don't correspond to an actual job or are on the wrong host */

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
@@ -1417,7 +1417,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
             if (moveAssignments.size() >= moveLimit || !canReceiveNewTasks(host) || moveAssignments.getBytesUsed() >= config.getBytesMovedFullRebalance()) {
                 break;
             }
-            List<JobTaskMoveAssignment> assignments = pushTasksOffHost(heavyHost, lightHostList,true, byteLimitFactor, 10, true);
+            List<JobTaskMoveAssignment> assignments = pushTasksOffHost(heavyHost, lightHostList,true, byteLimitFactor, 1, true);
 
             // Don't add tasks from the same job which were on different hosts
             for(JobTaskMoveAssignment assignment : assignments) {

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
@@ -1506,6 +1506,9 @@ public class SpawnBalancer implements Codable, AutoCloseable {
         Map<String, Boolean> snapshot = new HashMap<>(recentlyBalancedHosts.asMap());
         for (JobTaskMoveAssignment assignment : candidateAssignments) {
             String newHostID = assignment.getTargetUUID();
+            if(assignment.delete()) {
+                rv.add(assignment);
+            }
             if (newHostID == null) {
                 continue;
             }

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
@@ -1416,6 +1416,12 @@ public class SpawnBalancer implements Codable, AutoCloseable {
         return rv;
     }
 
+    /**
+     * Pushes one task from each heavyHost on to the lightHost
+     * @param host lightHost to receive tasks
+     * @param heavyHosts list of heavyHosts
+     * @return list of valid JobTaskMoveAssignment(s)
+     */
     private List<JobTaskMoveAssignment> pushTasksOntoHost(HostState host, Collection<HostState> heavyHosts) {
         int moveLimit = config.getTasksMovedFullRebalance();
         MoveAssignmentList moveAssignments = new MoveAssignmentList(spawn, taskSizer);
@@ -1506,10 +1512,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
         Map<String, Boolean> snapshot = new HashMap<>(recentlyBalancedHosts.asMap());
         for (JobTaskMoveAssignment assignment : candidateAssignments) {
             String newHostID = assignment.getTargetUUID();
-            if(assignment.delete()) {
-                rv.add(assignment);
-            }
-            if (newHostID == null) {
+            if (newHostID == null && !assignment.delete()) {
                 continue;
             }
             JobKey jobKey = assignment.getJobKey();

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
@@ -409,7 +409,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
 
     public List<JobTaskMoveAssignment> pushTasksOffHostForFilesystemOkayFailure(HostState host, int moveLimit) {
         List<HostState> hosts = hostManager.listHostStatus(null);
-        return pushTasksOffHost(host, hosts, false, 1, moveLimit, false);
+        return pushTasksOffHost(host, hosts, false, moveLimit, false);
     }
 
     private List<JobTaskMoveAssignment> getMoveAssignments(HostState host, Collection<HostState> otherHosts,
@@ -446,11 +446,9 @@ public class SpawnBalancer implements Codable, AutoCloseable {
     private List<JobTaskMoveAssignment> pushTasksOffHost(HostState host,
                                                          Collection<HostState> otherHosts,
                                                          boolean limitBytes,
-                                                         double byteLimitFactor,
                                                          int moveLimit,
                                                          boolean obeyDontAutobalanceMe) {
-        long byteLimit = (long) byteLimitFactor * config.getBytesMovedFullRebalance();
-        List<JobTaskMoveAssignment> moveAssignments = getMoveAssignments(host, otherHosts, limitBytes, byteLimit, moveLimit, obeyDontAutobalanceMe);
+        List<JobTaskMoveAssignment> moveAssignments = getMoveAssignments(host, otherHosts, limitBytes, config.getBytesMovedFullRebalance(), moveLimit, obeyDontAutobalanceMe);
         markRecentlyReplicatedTo(moveAssignments);
         moveAssignments.addAll(purgeMisplacedTasks(host, moveLimit));
         return moveAssignments;
@@ -1045,7 +1043,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
             // Host disk is overloaded
             log.info("[spawn.balancer] {} categorized as overloaded host; looking for tasks to push off of it", hostID);
             List<HostState> lightHosts = sortedHosts.subList(0, numAlleviateHosts);
-            List<JobTaskMoveAssignment> moveAssignments = pushTasksOffHost(host, lightHosts, true, 1, config.getTasksMovedFullRebalance(), true);
+            List<JobTaskMoveAssignment> moveAssignments = pushTasksOffHost(host, lightHosts, true, config.getTasksMovedFullRebalance(), true);
             rv.addAll(moveAssignments);
         } else if (isExtremeHost(hostID, true, false)) {
             // Host disk is underloaded

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
@@ -1417,9 +1417,16 @@ public class SpawnBalancer implements Codable, AutoCloseable {
             if (moveAssignments.size() >= moveLimit || !canReceiveNewTasks(host) || moveAssignments.getBytesUsed() >= config.getBytesMovedFullRebalance()) {
                 break;
             }
-            moveAssignments.addAll(pushTasksOffHost(heavyHost, lightHostList, true, byteLimitFactor, 1, true));
-            // Update byteLimitFactor with available byte limit
-            byteLimitFactor = 1 - (moveAssignments.getBytesUsed() / config.getBytesMovedFullRebalance());
+            List<JobTaskMoveAssignment> assignments = pushTasksOffHost(heavyHost, lightHostList,true, byteLimitFactor, 10, true);
+
+            // Don't add tasks from the same job which were on different hosts
+            for(JobTaskMoveAssignment assignment : assignments) {
+                if(!moveAssignments.contains(assignment.getJobKey())) {
+                    moveAssignments.add(assignment);
+                    // Update byteLimitFactor with available byte limit
+                    byteLimitFactor = 1 - (moveAssignments.getBytesUsed() / config.getBytesMovedFullRebalance());
+                }
+            }
         }
 
         rv.addAll(moveAssignments);

--- a/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancer.java
@@ -427,7 +427,7 @@ public class SpawnBalancer implements Codable, AutoCloseable {
         List<HostState> hostsSorted = sortHostsByDiskSpace(otherHosts);
 
         for (JobTask task : findTasksToMove(host, obeyDontAutobalanceMe)) {
-            if (moveAssignments.size() > moveLimit) {
+            if (moveAssignments.size() >= moveLimit) {
                 break;
             }
             long taskTrueSize = getTaskTrueSize(task);
@@ -1028,7 +1028,6 @@ public class SpawnBalancer implements Codable, AutoCloseable {
         }
         List<HostState> sortedHosts = sortHostsByDiskSpace(hosts);
         int numAlleviateHosts = (int) Math.ceil(sortedHosts.size() * config.getAlleviateHostPercentage());
-        numAlleviateHosts = sortedHosts.size() - 1;
         HostFailWorker.FailState failState = spawn.getHostFailWorker().getFailureState(hostID);
         if ((failState == HostFailWorker.FailState.FAILING_FS_OKAY) || isExtremeHost(hostID, true, true) ||
             (host.getAvailDiskBytes() < config.getMinFreeDiskSpaceToRecieveNewTasks())) {

--- a/hydra-main/src/test/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerTest.java
+++ b/hydra-main/src/test/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerTest.java
@@ -119,7 +119,7 @@ public class SpawnBalancerTest extends ZkCodecStartUtil {
             nextHost.setUp(true);
             hosts.add(nextHost);
         }
-        bal.markRecentlyReplicatedTo("id4");
+        bal.markRecentlyReplicatedTo(Arrays.asList(new JobTaskMoveAssignment(new JobKey(), "", "id4", false, false)));
         hosts = bal.sortHostsByDiskSpace(hosts);
         assertEquals("should get lightest host first", "id0", hosts.get(0).getHostUuid());
         assertEquals("should get heaviest host second to last", "id" + (numHosts - 1), hosts.get(numHosts - 2).getHostUuid());

--- a/hydra-main/src/test/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerTest.java
+++ b/hydra-main/src/test/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerTest.java
@@ -325,6 +325,7 @@ public class SpawnBalancerTest extends ZkCodecStartUtil {
         lightHost1.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
         lightHost1.setUsed(new HostCapacity(10, 10, 10, 200_000_0000L));
 
+
         String lightHost2UUID = "light2";
         HostState lightHost2 = installHostStateWithUUID(lightHost2UUID, spawn, true);
         lightHost2.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
@@ -360,6 +361,10 @@ public class SpawnBalancerTest extends ZkCodecStartUtil {
         assertTrue("should move something", !assignments.isEmpty());
         assertTrue("should not move too much", bytesMoved <= bal.getConfig().getBytesMovedFullRebalance());
 
+
+        // Clear recently balanced hosts
+        bal.clearRecentlyRebalancedHosts();
+
         // Suppose we have one host with under-utilized disk and other hosts with overloaded disks.
         // Should move some tasks from heavy to light, but not too much.
         // Test that rebalance moved tasks on to a light host from heavy hosts
@@ -374,6 +379,7 @@ public class SpawnBalancerTest extends ZkCodecStartUtil {
         }
         assertTrue("should move something", !assignments.isEmpty());
         assertTrue("should not move too much", bytesMoved <= bal.getConfig().getBytesMovedFullRebalance());
+
     }
 
     @Test

--- a/hydra-main/src/test/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerTest.java
+++ b/hydra-main/src/test/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerTest.java
@@ -118,9 +118,8 @@ public class SpawnBalancerTest extends ZkCodecStartUtil {
         // Delete the job
         spawn.deleteJob(job.getId());
 
-        String rebalanceMessage = spawn.rebalanceHost("host").toString();
-        String optimizedDirs = rebalanceMessage.substring(rebalanceMessage.indexOf("JobTaskMoveAssignment"));
-        assertTrue("should not fail to delete orphan task", !optimizedDirs.isEmpty());
+        int optimizedDirsIndex = spawn.rebalanceHost("host").toString().indexOf("JobTaskMoveAssignment");
+        assertTrue("should not fail to delete orphan task", optimizedDirsIndex != -1);
     }
 
     @Test

--- a/hydra-main/src/test/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerTest.java
+++ b/hydra-main/src/test/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerTest.java
@@ -303,41 +303,74 @@ public class SpawnBalancerTest extends ZkCodecStartUtil {
 
     @Test
     public void diskSpaceBalancingTest() throws Exception {
-        // Suppose we have one host with full disk and another with mostly empty disk.
-        // Should move some tasks from heavy to light, but not too much.
-        String heavyHostUUID = "heavy";
-        String lightHostUUID = "light";
+        String heavyHost1UUID = "heavy1";
+        HostState heavyHost1 = installHostStateWithUUID(heavyHost1UUID, spawn, true);
+        Job gargantuanJob = createSpawnJob(spawn, 1, Arrays.asList(heavyHost1UUID), now, 80_000_000_000L, 0);
+        Job movableJob1 = createSpawnJob(spawn, 1, Arrays.asList(heavyHost1UUID), now, 850_000_000L, 0);
+        Job movableJob2 = createSpawnJob(spawn, 1, Arrays.asList(heavyHost1UUID), now, 820_000_000L, 0);
+        heavyHost1.setStopped(simulateJobKeys(gargantuanJob, movableJob1, movableJob2));
+        heavyHost1.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
+        heavyHost1.setUsed(new HostCapacity(10, 10, 10, 90_900_000_000L));
+
+        String heavyHost2UUID = "heavy2";
+        HostState heavyHost2 = installHostStateWithUUID(heavyHost2UUID, spawn, true);
+        Job movableJob3 = createSpawnJob(spawn, 1, Arrays.asList(heavyHost2UUID), now, 820_000_000L, 0);
+        Job movableJob4 = createSpawnJob(spawn, 1, Arrays.asList(heavyHost2UUID), now, 850_000_000L, 0);
+        heavyHost2.setStopped(simulateJobKeys(movableJob3, movableJob4));
+        heavyHost2.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
+        heavyHost2.setUsed(new HostCapacity(10, 10, 10, 90_900_000_000L));
+
+        String lightHost1UUID = "light1";
+        HostState lightHost1 = installHostStateWithUUID(lightHost1UUID, spawn, true);
+        lightHost1.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
+        lightHost1.setUsed(new HostCapacity(10, 10, 10, 200_000_0000L));
+
         String lightHost2UUID = "light2";
-        String readOnlyHostUUID = "readOnlyHost";
-        HostState heavyHost = installHostStateWithUUID(heavyHostUUID, spawn, true);
-        HostState lightHost = installHostStateWithUUID(lightHostUUID, spawn, true);
         HostState lightHost2 = installHostStateWithUUID(lightHost2UUID, spawn, true);
-        HostState readOnlyHost = installHostStateWithUUID(readOnlyHostUUID, spawn, true, true, 0, "default");
-        List<HostState> hosts = Arrays.asList(heavyHost, lightHost, lightHost2, readOnlyHost);
-        spawn.getJobCommandManager().putEntity("foo", new JobCommand(), false);
-        Job gargantuanJob = createSpawnJob(spawn, 1, Arrays.asList(heavyHostUUID), now, 80_000_000_000L, 0);
-        Job movableJob1 = createSpawnJob(spawn, 1, Arrays.asList(heavyHostUUID), now, 850_000_000L, 0);
-        Job movableJob2 = createSpawnJob(spawn, 1, Arrays.asList(heavyHostUUID), now, 820_000_000L, 0);
-        heavyHost.setStopped(simulateJobKeys(gargantuanJob, movableJob1, movableJob2));
-        heavyHost.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
-        heavyHost.setUsed(new HostCapacity(10, 10, 10, 90_900_000_000L));
-        lightHost.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
-        lightHost.setUsed(new HostCapacity(10, 10, 10, 200_000_0000L));
         lightHost2.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
         lightHost2.setUsed(new HostCapacity(10, 10, 10, 200_000_000L));
+
+        String readOnlyHostUUID = "readOnlyHost";
+        HostState readOnlyHost = installHostStateWithUUID(readOnlyHostUUID, spawn, true, true, 0, "default");
         readOnlyHost.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
         readOnlyHost.setUsed(new HostCapacity(10, 10, 10, 200_000_000L));
-        hostManager.updateHostState(heavyHost);
-        hostManager.updateHostState(lightHost);
+
+
+        List<HostState> hostsForOverUtilizedTest = Arrays.asList(heavyHost1, lightHost1, lightHost2, readOnlyHost);
+        List<HostState> hostsForUnderUtilizedTest = Arrays.asList(heavyHost1, heavyHost2, lightHost1, readOnlyHost);
+
+        spawn.getJobCommandManager().putEntity("foo", new JobCommand(), false);
+        hostManager.updateHostState(heavyHost1);
+        hostManager.updateHostState(heavyHost2);
+        hostManager.updateHostState(lightHost1);
         hostManager.updateHostState(lightHost2);
         hostManager.updateHostState(readOnlyHost);
         bal.updateAggregateStatistics(hostManager.listHostStatus(null));
-        List<JobTaskMoveAssignment> assignments = bal.getAssignmentsToBalanceHost(heavyHost, hosts);
+
+        // Suppose we have one host with full disk and another with mostly empty disk.
+        // Should move some tasks from heavy to light, but not too much.
+        // Test that rebalance moved tasks off a heavy host to the light hosts
+        List<JobTaskMoveAssignment> assignments = bal.getAssignmentsToBalanceHost(heavyHost1, hostsForOverUtilizedTest);
         long bytesMoved = 0;
         for (JobTaskMoveAssignment assignment : assignments) {
             bytesMoved += bal.getTaskTrueSize(spawn.getTask(assignment.getJobKey()));
             assertTrue("shouldn't move gargantuan task", !assignment.getJobKey().getJobUuid().equals(gargantuanJob.getId()));
             assertTrue("shouldn't move to read-only host", !(assignment.getTargetUUID().equals(readOnlyHostUUID)));
+        }
+        assertTrue("should move something", !assignments.isEmpty());
+        assertTrue("should not move too much", bytesMoved <= bal.getConfig().getBytesMovedFullRebalance());
+
+        // Suppose we have one host with under-utilized disk and other hosts with overloaded disks.
+        // Should move some tasks from heavy to light, but not too much.
+        // Test that rebalance moved tasks on to a light host from heavy hosts
+        assignments = bal.getAssignmentsToBalanceHost(lightHost1, hostsForUnderUtilizedTest);
+        bytesMoved = 0;
+
+        for (JobTaskMoveAssignment assignment : assignments) {
+            bytesMoved += bal.getTaskTrueSize(spawn.getTask(assignment.getJobKey()));
+            assertTrue("shouldn't move gargantuan task",
+                       !assignment.getJobKey().getJobUuid().equals(gargantuanJob.getId()));
+            assertTrue("shouldn't move from read-only host", !(assignment.getSourceUUID().equals(readOnlyHostUUID)));
         }
         assertTrue("should move something", !assignments.isEmpty());
         assertTrue("should not move too much", bytesMoved <= bal.getConfig().getBytesMovedFullRebalance());
@@ -504,58 +537,6 @@ public class SpawnBalancerTest extends ZkCodecStartUtil {
         downstreamJob.setParameters(Arrays.asList(new JobParameter("param", sourceJob.getId(), "DEFAULT")));
         spawn.updateJob(downstreamJob);
         assertEquals("dependency graph should have two nodes", 2, spawn.getJobDependencies().getNodes().size());
-    }
-
-    @Test
-    public void underutilizedHostRebalanceTest() throws Exception {
-        // Suppose we have one host with under-utilized disk and other hosts with overloaded disks.
-        // Should move some tasks from heavy to light, but not too much.
-
-        String heavyHost1UUID = "heavy1";
-        HostState heavyHost1 = installHostStateWithUUID(heavyHost1UUID, spawn, true);
-        Job gargantuanJob = createSpawnJob(spawn, 1, Arrays.asList(heavyHost1UUID), now, 80_000_000_000L, 0);
-        Job movableJob1 = createSpawnJob(spawn, 1, Arrays.asList(heavyHost1UUID), now, 850_000_000L, 0);
-        Job movableJob2 = createSpawnJob(spawn, 1, Arrays.asList(heavyHost1UUID), now, 820_000_000L, 0);
-        heavyHost1.setStopped(simulateJobKeys(gargantuanJob, movableJob1, movableJob2));
-        heavyHost1.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
-        heavyHost1.setUsed(new HostCapacity(10, 10, 10, 90_900_000_000L));
-
-        String heavyHost2UUID = "heavy2";
-        HostState heavyHost2 = installHostStateWithUUID(heavyHost2UUID, spawn, true);
-        Job movableJob3 = createSpawnJob(spawn, 1, Arrays.asList(heavyHost2UUID), now, 820_000_000L, 0);
-        Job movableJob4 = createSpawnJob(spawn, 1, Arrays.asList(heavyHost2UUID), now, 850_000_000L, 0);
-        heavyHost2.setStopped(simulateJobKeys(movableJob3, movableJob4));
-        heavyHost2.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
-        heavyHost2.setUsed(new HostCapacity(10, 10, 10, 90_900_000_000L));
-
-        String lightHostUUID = "light";
-        HostState lightHost = installHostStateWithUUID(lightHostUUID, spawn, true);
-        lightHost.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
-        lightHost.setUsed(new HostCapacity(10, 10, 10, 200_000_0000L));
-
-        String readOnlyHostUUID = "readOnlyHost";
-        HostState readOnlyHost = installHostStateWithUUID(readOnlyHostUUID, spawn, true, true, 0, "default");
-        readOnlyHost.setMax(new HostCapacity(10, 10, 10, 100_000_000_000L));
-        readOnlyHost.setUsed(new HostCapacity(10, 10, 10, 200_000_000L));
-
-        List<HostState> hosts = Arrays.asList(heavyHost1, heavyHost2, lightHost, readOnlyHost);
-        spawn.getJobCommandManager().putEntity("foo", new JobCommand(), false);
-        hostManager.updateHostState(heavyHost1);
-        hostManager.updateHostState(heavyHost2);
-        hostManager.updateHostState(lightHost);
-        hostManager.updateHostState(readOnlyHost);
-        bal.updateAggregateStatistics(hostManager.listHostStatus(null));
-        List<JobTaskMoveAssignment> assignments = bal.getAssignmentsToBalanceHost(lightHost, hosts);
-        long bytesMoved = 0;
-
-        for (JobTaskMoveAssignment assignment : assignments) {
-            bytesMoved += bal.getTaskTrueSize(spawn.getTask(assignment.getJobKey()));
-            assertTrue("shouldn't move gargantuan task",
-                       !assignment.getJobKey().getJobUuid().equals(gargantuanJob.getId()));
-            assertTrue("shouldn't move from read-only host", !(assignment.getSourceUUID().equals(readOnlyHostUUID)));
-        }
-        assertTrue("should move something", !assignments.isEmpty());
-        assertTrue("should not move too much", bytesMoved <= bal.getConfig().getBytesMovedFullRebalance());
     }
 
     private Job createSpawnJob(Spawn spawn, int numTasks, List<String> hosts, long startTime, long taskSizeBytes, int numReplicas) throws Exception {

--- a/hydra-main/src/test/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerTest.java
+++ b/hydra-main/src/test/java/com/addthis/hydra/job/spawn/balancer/SpawnBalancerTest.java
@@ -52,7 +52,10 @@ import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
 import static com.addthis.hydra.job.IJob.DEFAULT_MINION_TYPE;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @Category(SlowTest.class)
 public class SpawnBalancerTest extends ZkCodecStartUtil {
@@ -550,6 +553,17 @@ public class SpawnBalancerTest extends ZkCodecStartUtil {
         downstreamJob.setParameters(Arrays.asList(new JobParameter("param", sourceJob.getId(), "DEFAULT")));
         spawn.updateJob(downstreamJob);
         assertEquals("dependency graph should have two nodes", 2, spawn.getJobDependencies().getNodes().size());
+    }
+
+    @Test
+    public  void moveAssignmentListTest() throws Exception {
+        MoveAssignmentList moveAssignmentList = new MoveAssignmentList(spawn, new SpawnBalancerTaskSizer(spawn, hostManager));
+        // Add a live task
+        boolean addTask = moveAssignmentList.add(new JobTaskMoveAssignment(new JobKey("job1", 0), "srcHost", "destHost", false, false));
+        assertTrue("should add live", addTask);
+        // Try to add a replica of the live task
+        addTask = moveAssignmentList.add(new JobTaskMoveAssignment(new JobKey("job1", 0), "srcHost", "destHost", true, false));
+        assertTrue("should not add replica", !addTask);
     }
 
     private Job createSpawnJob(Spawn spawn, int numTasks, List<String> hosts, long startTime, long taskSizeBytes, int numReplicas) throws Exception {


### PR DESCRIPTION
moveLimit parameter added to limit tasks moved to light hosts after rebalance. Also fixed unit test (overloaded host rebalance) to avoid moving tasks to readonly hosts.