### PR TITLE
[WIP] changed the file writing mode to avoid an empty minion.state wh…

### DIFF
--- a/hydra-main/src/main/java/com/addthis/hydra/minion/CommandTaskDeleteRunner.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/minion/CommandTaskDeleteRunner.java
@@ -43,7 +43,7 @@ class CommandTaskDeleteRunner implements Runnable {
                 task.setDeleted(true);
                 minion.tasks.remove(task.getJobKey().toString());
                 log.warn("[task.delete] {} terminated={}", task.getJobKey(), terminated);
-                minion.writeState();
+                minion.writeState(true);
             }
             File taskDirFile = new File(minion.rootDir + "/" + delete.getJobUuid() + (delete.getNodeID() != null ? "/" + delete.getNodeID() : ""));
             if (taskDirFile.exists() && taskDirFile.isDirectory()) {
@@ -52,6 +52,5 @@ class CommandTaskDeleteRunner implements Runnable {
         } finally {
             minion.minionStateLock.unlock();
         }
-
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/minion/CommandTaskRevertRunner.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/minion/CommandTaskRevertRunner.java
@@ -63,6 +63,6 @@ class CommandTaskRevertRunner implements Runnable {
                 log.warn("[task.revert] " + task.getJobKey() + " completed in " + (System.currentTimeMillis() - time) + "ms.");
             }
         }
-        minion.writeState();
+        minion.writeState(true);
     }
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/minion/CommandTaskStopRunner.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/minion/CommandTaskStopRunner.java
@@ -63,7 +63,7 @@ class CommandTaskStopRunner implements Runnable {
                 task.sendEndStatus(task.findLastJobStatus());
             }
         }
-        minion.writeState();
+        minion.writeState(true);
     }
 
 }

--- a/hydra-main/src/main/java/com/addthis/hydra/minion/JobTask.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/minion/JobTask.java
@@ -22,10 +22,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.function.Function;
 
 import com.addthis.basis.util.LessBytes;
 import com.addthis.basis.util.LessFiles;
@@ -35,7 +35,11 @@ import com.addthis.basis.util.SimpleExec;
 import com.addthis.codec.annotations.FieldConfig;
 import com.addthis.codec.codables.Codable;
 import com.addthis.codec.json.CodecJSON;
-import com.addthis.hydra.job.*;
+import com.addthis.hydra.job.BackupWorkItem;
+import com.addthis.hydra.job.JobTaskErrorCode;
+import com.addthis.hydra.job.JobTaskState;
+import com.addthis.hydra.job.ReplicateWorkItem;
+import com.addthis.hydra.job.RunTaskWorkItem;
 import com.addthis.hydra.job.backup.DailyBackup;
 import com.addthis.hydra.job.backup.GoldBackup;
 import com.addthis.hydra.job.backup.HourlyBackup;
@@ -446,7 +450,7 @@ public class JobTask implements Codable {
                 }
             }
         }
-        minion.writeState();
+        minion.writeState(true);
         return copyCommands;
     }
 
@@ -1255,7 +1259,7 @@ public class JobTask implements Codable {
         return result;
     }
 
-    private void resetStartTime() {
+    protected void resetStartTime() {
         if (isRunning()) {
             startTime = 0;
         } else if (isReplicating()) {
@@ -1263,7 +1267,7 @@ public class JobTask implements Codable {
         } else if (isBackingUp()) {
             backupStartTime = 0;
         }
-        minion.writeState();
+        minion.writeState(true);
     }
 
     public File getLiveDir() {

--- a/hydra-main/src/main/java/com/addthis/hydra/minion/TaskRunner.java
+++ b/hydra-main/src/main/java/com/addthis/hydra/minion/TaskRunner.java
@@ -60,7 +60,13 @@ class TaskRunner extends Thread {
                 minion.channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
             } catch (InterruptedException ex) {
                 log.warn("Interrupted while processing task messages");
-                minion.shutdown();
+                try {
+                    minion.close();
+                } catch (Exception e) {
+                    log.error("Minion close throws an exception", e);
+                } finally {
+                    minion.shutdown();
+                }
             } catch (ShutdownSignalException shutdownException) {
                 log.warn("Received unexpected shutdown exception from rabbitMQ", shutdownException);
                 try {
@@ -80,7 +86,13 @@ class TaskRunner extends Thread {
                 if (!(ex instanceof ExecException)) {
                     log.error("Error nacking message", ex);
                 }
-                minion.shutdown();
+                try {
+                    minion.close();
+                } catch (Exception e) {
+                    log.error("Minion close throws an exception", e);
+                } finally {
+                    minion.shutdown();
+                }
             }
         }
     }


### PR DESCRIPTION
- Changed such that file can be appended except when minion starts (which is the same in the original code)
- added minion close before shutdown when TaskRunner run throws an exception

There are two places 
(run method in  CommandTaskDeleteRunner and kickNextJob method in Minion) 
where they use minionStateLock again 
even though writeState() is already locking via minionStateLock.
Since this is ReentrantLock, it's no harm, but wondering why they use this way.
